### PR TITLE
Make Java & Spring Boot versions consumer-controlled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Four Maven modules with a strict dependency hierarchy:
 
 ## Virtual Thread Conventions
 
-- Jetty handles each request on a virtual thread (`spring.threads.virtual.enabled: true`)
+- Embedded server handles each request on a virtual thread (`spring.threads.virtual.enabled: true`)
 - Each DAG node runs on its own virtual thread
 - Service calls use blocking `RestClient` (virtual thread unmounts during I/O)
 - **Never use `synchronized`** — use `ReentrantLock` instead to avoid carrier thread pinning
@@ -64,7 +64,7 @@ Four Maven modules with a strict dependency hierarchy:
 ## Tech Stack
 
 - Java 21 (compiled with `-parameters` flag)
-- Spring Boot 3.4.3 with Jetty
+- Spring Boot 3.4+ (version provided by consumer's project; starter is server-agnostic)
 - Lombok (used in loom-core)
 - dsl-json for JSON serialization (via `JsonCodec` abstraction in `io.loom.core.codec`)
 - springdoc-openapi 2.8.6 for Swagger/OpenAPI

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 ║               ║           ║           ║                              ║
 ║     Scatter ──╬── Gather ─╬── Weave ──╬── Respond                    ║
 ║               ║           ║           ║                              ║
-║        ─ ─ ═══╩══ ─ ─ ═══╩══ ─ ─ ═══╩══ ─ ─                          ║
+║        ─ ─ ═══╩══  ─ ─ ═══╩══  ─ ─ ═══╩══ ─ ─                        ║
 ║                                                                      ║
-║     DAG Scatter-Gather ∙ Virtual Threads ∙ Spring Boot ∙ Java 21     ║
+║     DAG Scatter-Gather ∙ Virtual Threads ∙ Spring Boot ∙ Java 21+    ║
 ║                                                                      ║
 ╚══════════════════════════════════════════════════════════════════════╝
 ```
@@ -88,6 +88,26 @@ everything.
 <version>0.1.0-SNAPSHOT</version>
 </dependency>
 ```
+
+> **Server choice:** The starter is server-agnostic — Spring Boot defaults to Tomcat.
+> To use Jetty instead (recommended for virtual threads on older Spring Boot versions):
+>
+> ```xml
+> <dependency>
+>   <groupId>org.springframework.boot</groupId>
+>   <artifactId>spring-boot-starter-web</artifactId>
+>   <exclusions>
+>     <exclusion>
+>       <groupId>org.springframework.boot</groupId>
+>       <artifactId>spring-boot-starter-tomcat</artifactId>
+>     </exclusion>
+>   </exclusions>
+> </dependency>
+> <dependency>
+>   <groupId>org.springframework.boot</groupId>
+>   <artifactId>spring-boot-starter-jetty</artifactId>
+> </dependency>
+> ```
 
 ### 2. Define a DAG API
 
@@ -214,7 +234,7 @@ Then visit `http://localhost:8080/loom/ui`.
 ## Architecture
 
 ```
-HTTP Request (virtual thread via Jetty)
+HTTP Request (virtual thread)
   |
   v
 LoomHandlerMapping (path template match)
@@ -602,7 +622,7 @@ with exponential backoff is automatic based on service configuration.
 
 Loom uses virtual threads at every layer:
 
-1. **HTTP handling** — Jetty spawns virtual threads for each request (
+1. **HTTP handling** — Embedded server spawns virtual threads for each request (
    `spring.threads.virtual.enabled: true`)
 2. **DAG execution** — Each builder node runs on its own virtual thread via
    `Executors.newVirtualThreadPerTaskExecutor()`
@@ -649,7 +669,6 @@ Then visit:
 
 - Java 21+
 - Spring Boot 3.4+
-- Jetty (included via starter)
 
 ## License
 

--- a/loom-example/pom.xml
+++ b/loom-example/pom.xml
@@ -14,6 +14,12 @@
     <name>Loom Example</name>
     <description>Working demo application</description>
 
+    <properties>
+        <!-- Override to compile/run with a newer JDK (default: 21, inherited from loom-parent) -->
+        <!-- <java.version>25</java.version> -->
+        <!-- <maven.compiler.release>25</maven.compiler.release> -->
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.loom</groupId>
@@ -22,6 +28,20 @@
         <dependency>
             <groupId>io.loom</groupId>
             <artifactId>loom-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/loom-spring-boot-starter/pom.xml
+++ b/loom-spring-boot-starter/pom.xml
@@ -22,16 +22,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-tomcat</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-jetty</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/loom-ui/pom.xml
+++ b/loom-ui/pom.xml
@@ -26,12 +26,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-tomcat</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.3</version>
-        <relativePath/>
-    </parent>
-
     <groupId>io.loom</groupId>
     <artifactId>loom-parent</artifactId>
     <version>0.1.0-SNAPSHOT</version>
@@ -21,10 +14,19 @@
 
     <properties>
         <java.version>21</java.version>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <spring-boot.version>3.4.3</spring-boot.version>
         <lombok.version>1.18.30</lombok.version>
+
+        <!-- Plugin versions -->
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
+        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+        <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
     </properties>
 
     <modules>
@@ -36,6 +38,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.loom</groupId>
                 <artifactId>loom-core</artifactId>
@@ -55,17 +64,74 @@
     </dependencyManagement>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                    <configuration>
+                        <release>${maven.compiler.release}</release>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven-resources-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-enforcer-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>21</source>
-                    <target>21</target>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
-                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[21,)</version>
+                                    <message>Loom requires Java 21+ (virtual threads)</message>
+                                </requireJavaVersion>
+                                <requireMavenVersion>
+                                    <version>[3.8.0,)</version>
+                                    <message>Maven 3.8+ is required</message>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary

- **Remove `spring-boot-starter-parent` inheritance** — import `spring-boot-dependencies` BOM instead, so consumers control their own Spring Boot (>= 3.4.x) and Java (>= 21) versions
- **Add `pluginManagement`** — pin maven-compiler, surefire, jar, resources, spring-boot, and enforcer plugins that were previously inherited from the parent
- **Add `maven-enforcer-plugin`** — enforce Java 21+ and Maven 3.8+ at build time
- **Make starter server-agnostic** — remove forced Jetty dependency from `loom-spring-boot-starter` and `loom-ui`; the example app now makes the server choice (Jetty with Tomcat exclusion)
- **Update docs** — README and CLAUDE.md updated to reflect server-agnostic architecture and flexible versioning

## Test plan

- [x] `mvn clean install` — all 94 tests pass across all modules
- [x] `mvn help:effective-pom -pl loom-core` — confirms `<release>21</release>`, `-parameters` flag, surefire 3.5.2
- [x] `mvn dependency:tree -pl loom-spring-boot-starter` — no Jetty/Tomcat forced in starter
- [x] `mvn dependency:tree -pl loom-example` — example correctly uses Jetty
- [x] `cd loom-example && mvn spring-boot:run` — verify example app starts on Jetty

🤖 Generated with [Claude Code](https://claude.com/claude-code)