### PR TITLE
Performance optimizations, ServiceResponse API, and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
+dependency-reduced-pom.xml
 
 # IDE
 .idea/

--- a/loom-benchmark/pom.xml
+++ b/loom-benchmark/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.loom</groupId>
+        <artifactId>loom-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>loom-benchmark</artifactId>
+    <name>Loom Benchmark</name>
+    <description>JMH benchmarks for Loom framework performance validation</description>
+
+    <properties>
+        <jmh.version>1.37</jmh.version>
+        <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.loom</groupId>
+            <artifactId>loom-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.loom</groupId>
+            <artifactId>loom-spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- JMH -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Spring Mock for HttpServletRequest -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>benchmarks</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Skip surefire — benchmarks are not unit tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/loom-benchmark/src/main/java/io/loom/benchmark/ContextCreationBenchmark.java
+++ b/loom-benchmark/src/main/java/io/loom/benchmark/ContextCreationBenchmark.java
@@ -1,0 +1,85 @@
+package io.loom.benchmark;
+
+import io.loom.core.codec.DslJsonCodec;
+import io.loom.core.codec.JsonCodec;
+import io.loom.starter.web.LoomHttpContextImpl;
+
+import org.openjdk.jmh.annotations.*;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode({Mode.Throughput, Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class ContextCreationBenchmark {
+
+    private JsonCodec codec;
+    private MockHttpServletResponse response;
+
+    @Setup
+    public void setup() {
+        codec = new DslJsonCodec();
+        response = new MockHttpServletResponse();
+    }
+
+    private MockHttpServletRequest buildRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users/42/orders");
+        // 12 headers
+        request.addHeader("Accept", "application/json");
+        request.addHeader("Content-Type", "application/json");
+        request.addHeader("Authorization", "Bearer token-abc-123");
+        request.addHeader("X-Request-Id", "req-12345");
+        request.addHeader("X-Correlation-Id", "corr-67890");
+        request.addHeader("User-Agent", "BenchmarkClient/1.0");
+        request.addHeader("Host", "localhost:8080");
+        request.addHeader("Connection", "keep-alive");
+        request.addHeader("Cache-Control", "no-cache");
+        request.addHeader("Accept-Encoding", "gzip, deflate");
+        request.addHeader("Accept-Language", "en-US");
+        request.addHeader("X-Forwarded-For", "10.0.0.1");
+        // 5 query params
+        request.addParameter("page", "1");
+        request.addParameter("size", "20");
+        request.addParameter("sort", "name");
+        request.addParameter("filter", "active");
+        request.addParameter("fields", "id,name,email");
+        return request;
+    }
+
+    @Benchmark
+    public LoomHttpContextImpl createContextNoHeaderAccess() {
+        MockHttpServletRequest request = buildRequest();
+        Map<String, String> pathVars = Map.of("userId", "42");
+        return new LoomHttpContextImpl(request, response, codec, pathVars, 10_485_760);
+    }
+
+    @Benchmark
+    public Object createContextWithHeaderAccess() {
+        MockHttpServletRequest request = buildRequest();
+        Map<String, String> pathVars = Map.of("userId", "42");
+        LoomHttpContextImpl ctx = new LoomHttpContextImpl(request, response, codec, pathVars, 10_485_760);
+        return ctx.getHeaders();
+    }
+
+    @Benchmark
+    public Object createContextWithQueryParamAccess() {
+        MockHttpServletRequest request = buildRequest();
+        Map<String, String> pathVars = Map.of("userId", "42");
+        LoomHttpContextImpl ctx = new LoomHttpContextImpl(request, response, codec, pathVars, 10_485_760);
+        return ctx.getQueryParams();
+    }
+
+    @Benchmark
+    public String singleHeaderAccess() {
+        MockHttpServletRequest request = buildRequest();
+        Map<String, String> pathVars = Map.of("userId", "42");
+        LoomHttpContextImpl ctx = new LoomHttpContextImpl(request, response, codec, pathVars, 10_485_760);
+        return ctx.getHeader("Authorization");
+    }
+}

--- a/loom-benchmark/src/main/java/io/loom/benchmark/DagExecutorBenchmark.java
+++ b/loom-benchmark/src/main/java/io/loom/benchmark/DagExecutorBenchmark.java
@@ -1,0 +1,184 @@
+package io.loom.benchmark;
+
+import io.loom.core.builder.BuilderContext;
+import io.loom.core.builder.LoomBuilder;
+import io.loom.core.engine.Dag;
+import io.loom.core.engine.DagCompiler;
+import io.loom.core.engine.DagExecutor;
+import io.loom.core.annotation.LoomApi;
+import io.loom.core.annotation.LoomGraph;
+import io.loom.core.annotation.Node;
+import io.loom.core.exception.LoomDependencyResolutionException;
+import io.loom.core.registry.BuilderFactory;
+import io.loom.core.service.ServiceAccessor;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode({Mode.Throughput, Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class DagExecutorBenchmark {
+
+    // ── Response types ──
+
+    public record UserData(String id, String name) {}
+    public record ConfigData(String region) {}
+    public record EnrichedData(String id, String name, String region) {}
+    public record OrderData(List<String> orderIds) {}
+    public record DashboardResponse(String userId, String region, int orderCount) {}
+
+    // ── Mock builders (instant return, no I/O) ──
+
+    public static class FetchUserBuilder implements LoomBuilder<UserData> {
+        public UserData build(BuilderContext ctx) { return new UserData("u-1", "Alice"); }
+    }
+    public static class FetchConfigBuilder implements LoomBuilder<ConfigData> {
+        public ConfigData build(BuilderContext ctx) { return new ConfigData("us-east-1"); }
+    }
+    public static class EnrichBuilder implements LoomBuilder<EnrichedData> {
+        public EnrichedData build(BuilderContext ctx) {
+            UserData u = ctx.getDependency(UserData.class);
+            ConfigData c = ctx.getDependency(ConfigData.class);
+            return new EnrichedData(u.id(), u.name(), c.region());
+        }
+    }
+    public static class FetchOrdersBuilder implements LoomBuilder<OrderData> {
+        public OrderData build(BuilderContext ctx) {
+            return new OrderData(List.of("o-1", "o-2", "o-3"));
+        }
+    }
+    public static class AssembleBuilder implements LoomBuilder<DashboardResponse> {
+        public DashboardResponse build(BuilderContext ctx) {
+            EnrichedData e = ctx.getDependency(EnrichedData.class);
+            OrderData o = ctx.getDependency(OrderData.class);
+            return new DashboardResponse(e.id(), e.region(), o.orderIds().size());
+        }
+    }
+
+    // ── DAG definition via annotations ──
+
+    @LoomApi(method = "GET", path = "/benchmark/dashboard", response = DashboardResponse.class)
+    @LoomGraph({
+        @Node(builder = FetchUserBuilder.class),
+        @Node(builder = FetchConfigBuilder.class),
+        @Node(builder = EnrichBuilder.class, dependsOn = {FetchUserBuilder.class, FetchConfigBuilder.class}),
+        @Node(builder = FetchOrdersBuilder.class, dependsOn = FetchUserBuilder.class),
+        @Node(builder = AssembleBuilder.class, dependsOn = {EnrichBuilder.class, FetchOrdersBuilder.class})
+    })
+    static class BenchmarkApi {}
+
+    private DagExecutor executor;
+    private Dag dag;
+
+    @Setup
+    public void setup() {
+        BuilderFactory factory = new BuilderFactory() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T> LoomBuilder<T> createBuilder(Class<? extends LoomBuilder<T>> type) {
+                return (LoomBuilder<T>) createBuilderUntyped(type);
+            }
+            @Override
+            public LoomBuilder<?> createBuilderUntyped(Class<? extends LoomBuilder<?>> type) {
+                if (type == FetchUserBuilder.class) return new FetchUserBuilder();
+                if (type == FetchConfigBuilder.class) return new FetchConfigBuilder();
+                if (type == EnrichBuilder.class) return new EnrichBuilder();
+                if (type == FetchOrdersBuilder.class) return new FetchOrdersBuilder();
+                if (type == AssembleBuilder.class) return new AssembleBuilder();
+                throw new IllegalArgumentException("Unknown builder: " + type);
+            }
+        };
+
+        DagCompiler compiler = new DagCompiler();
+        dag = compiler.compile(BenchmarkApi.class);
+        executor = new DagExecutor(factory);
+    }
+
+    @Benchmark
+    public Object executeDag() {
+        return executor.execute(dag, new StubBuilderContext());
+    }
+
+    // ── Minimal BuilderContext for benchmarking ──
+
+    static class StubBuilderContext implements BuilderContext {
+        private Object[] results;
+        private Map<Class<?>, Integer> typeIndexMap;
+        private Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap;
+        private static final Object NULL_SENTINEL = new Object();
+
+        @Override public <T> T getRequestBody(Class<T> type) { return null; }
+        @Override public String getPathVariable(String name) { return null; }
+        @Override public String getQueryParam(String name) { return null; }
+        @Override public String getHeader(String name) { return null; }
+        @Override public String getHttpMethod() { return "GET"; }
+        @Override public String getRequestPath() { return "/benchmark"; }
+        @Override public Map<String, String> getPathVariables() { return Map.of(); }
+        @Override public Map<String, List<String>> getQueryParams() { return Map.of(); }
+        @Override public Map<String, List<String>> getHeaders() { return Map.of(); }
+        @Override public byte[] getRawRequestBody() { return null; }
+        @Override public ServiceAccessor service(String name) { return null; }
+        @Override public void setAttribute(String key, Object value) {}
+        @Override @SuppressWarnings("unchecked")
+        public <T> T getAttribute(String key, Class<T> type) { return null; }
+        @Override public Map<String, Object> getAttributes() { return Map.of(); }
+
+        @Override
+        public void initResultStorage(int nodeCount,
+                                      Map<Class<?>, Integer> typeIndexMap,
+                                      Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap) {
+            this.results = new Object[nodeCount];
+            this.typeIndexMap = typeIndexMap;
+            this.builderIndexMap = builderIndexMap;
+        }
+
+        @Override
+        public void storeResult(Class<? extends LoomBuilder<?>> builderClass, Class<?> outputType, Object result) {
+            Object stored = result != null ? result : NULL_SENTINEL;
+            Integer index = builderIndexMap.get(builderClass);
+            if (index != null) results[index] = stored;
+        }
+
+        @Override @SuppressWarnings("unchecked")
+        public <T> T getDependency(Class<T> outputType) {
+            Integer index = typeIndexMap.get(outputType);
+            if (index == null || results[index] == null) {
+                throw new LoomDependencyResolutionException(outputType.getSimpleName(), List.of(), List.of());
+            }
+            Object r = results[index];
+            return r == NULL_SENTINEL ? null : (T) r;
+        }
+
+        @Override @SuppressWarnings("unchecked")
+        public <T> T getResultOf(Class<? extends LoomBuilder<T>> builderClass) {
+            Integer index = builderIndexMap.get(builderClass);
+            if (index == null || results[index] == null) {
+                throw new LoomDependencyResolutionException("builder:" + builderClass.getSimpleName(), List.of(), List.of());
+            }
+            Object r = results[index];
+            return r == NULL_SENTINEL ? null : (T) r;
+        }
+
+        @Override @SuppressWarnings("unchecked")
+        public <T> Optional<T> getOptionalDependency(Class<T> outputType) {
+            Integer index = typeIndexMap != null ? typeIndexMap.get(outputType) : null;
+            if (index == null) return Optional.empty();
+            Object v = results[index];
+            return v == null ? Optional.empty() : Optional.ofNullable(v == NULL_SENTINEL ? null : (T) v);
+        }
+
+        @Override @SuppressWarnings("unchecked")
+        public <T> Optional<T> getOptionalResultOf(Class<? extends LoomBuilder<T>> builderClass) {
+            Integer index = builderIndexMap != null ? builderIndexMap.get(builderClass) : null;
+            if (index == null) return Optional.empty();
+            Object v = results[index];
+            return v == null ? Optional.empty() : Optional.ofNullable(v == NULL_SENTINEL ? null : (T) v);
+        }
+    }
+}

--- a/loom-benchmark/src/main/java/io/loom/benchmark/EndToEndBenchmark.java
+++ b/loom-benchmark/src/main/java/io/loom/benchmark/EndToEndBenchmark.java
@@ -1,0 +1,245 @@
+package io.loom.benchmark;
+
+import io.loom.core.annotation.LoomApi;
+import io.loom.core.annotation.LoomGraph;
+import io.loom.core.annotation.Node;
+import io.loom.core.builder.BuilderContext;
+import io.loom.core.builder.LoomBuilder;
+import io.loom.core.codec.DslJsonCodec;
+import io.loom.core.codec.JsonCodec;
+import io.loom.core.engine.Dag;
+import io.loom.core.engine.DagCompiler;
+import io.loom.core.engine.DagExecutor;
+import io.loom.core.exception.LoomDependencyResolutionException;
+import io.loom.core.model.ApiDefinition;
+import io.loom.core.registry.BuilderFactory;
+import io.loom.core.service.ServiceAccessor;
+import io.loom.starter.web.LoomHttpContextImpl;
+import io.loom.starter.web.RouteTrie;
+
+import org.openjdk.jmh.annotations.*;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures the full CPU-bound pipeline: route match -> context creation ->
+ * DAG execution -> JSON serialization. No network I/O.
+ *
+ * If this achieves >50K ops/sec single-threaded, with virtual threads on
+ * 4 vCPU the framework can sustain 20-30K+ real TPS (where most time is
+ * spent waiting on upstream I/O, not CPU work).
+ */
+@BenchmarkMode({Mode.Throughput, Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class EndToEndBenchmark {
+
+    // ── Types ──
+
+    public record UserData(String id, String name) {}
+    public record ConfigData(String region) {}
+    public record EnrichedData(String id, String name, String region) {}
+    public record OrderData(List<String> orderIds) {}
+    public record ApiResponse(String userId, String region, int orderCount) {}
+
+    // ── Builders (no I/O) ──
+
+    public static class FetchUserBuilder implements LoomBuilder<UserData> {
+        public UserData build(BuilderContext ctx) { return new UserData("u-1", "Alice"); }
+    }
+    public static class FetchConfigBuilder implements LoomBuilder<ConfigData> {
+        public ConfigData build(BuilderContext ctx) { return new ConfigData("us-east-1"); }
+    }
+    public static class EnrichBuilder implements LoomBuilder<EnrichedData> {
+        public EnrichedData build(BuilderContext ctx) {
+            UserData u = ctx.getDependency(UserData.class);
+            ConfigData c = ctx.getDependency(ConfigData.class);
+            return new EnrichedData(u.id(), u.name(), c.region());
+        }
+    }
+    public static class FetchOrdersBuilder implements LoomBuilder<OrderData> {
+        public OrderData build(BuilderContext ctx) {
+            return new OrderData(List.of("o-1", "o-2", "o-3"));
+        }
+    }
+    public static class AssembleBuilder implements LoomBuilder<ApiResponse> {
+        public ApiResponse build(BuilderContext ctx) {
+            EnrichedData e = ctx.getDependency(EnrichedData.class);
+            OrderData o = ctx.getDependency(OrderData.class);
+            return new ApiResponse(e.id(), e.region(), o.orderIds().size());
+        }
+    }
+
+    @LoomApi(method = "GET", path = "/api/users/{userId}/dashboard", response = ApiResponse.class)
+    @LoomGraph({
+        @Node(builder = FetchUserBuilder.class),
+        @Node(builder = FetchConfigBuilder.class),
+        @Node(builder = EnrichBuilder.class, dependsOn = {FetchUserBuilder.class, FetchConfigBuilder.class}),
+        @Node(builder = FetchOrdersBuilder.class, dependsOn = FetchUserBuilder.class),
+        @Node(builder = AssembleBuilder.class, dependsOn = {EnrichBuilder.class, FetchOrdersBuilder.class})
+    })
+    static class BenchmarkApi {}
+
+    // ── State ──
+
+    private RouteTrie routeTrie;
+    private DagExecutor executor;
+    private Dag dag;
+    private JsonCodec codec;
+    private MockHttpServletResponse mockResponse;
+
+    @Setup
+    public void setup() {
+        codec = new DslJsonCodec();
+        mockResponse = new MockHttpServletResponse();
+
+        // Route trie with the benchmark route + some others for realism
+        routeTrie = new RouteTrie();
+        ApiDefinition benchApi = new ApiDefinition("GET", "/api/users/{userId}/dashboard",
+                null, ApiResponse.class, null, null, null, null, null, null, null, null, null, null, null);
+        routeTrie.insert(benchApi);
+
+        // Add some filler routes
+        for (int i = 0; i < 30; i++) {
+            routeTrie.insert(new ApiDefinition("GET", "/api/resource" + i + "/{id}",
+                    null, null, null, null, null, null, null, null, null, null, null, null, null));
+        }
+
+        BuilderFactory factory = new BuilderFactory() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T> LoomBuilder<T> createBuilder(Class<? extends LoomBuilder<T>> type) {
+                return (LoomBuilder<T>) createBuilderUntyped(type);
+            }
+            @Override
+            public LoomBuilder<?> createBuilderUntyped(Class<? extends LoomBuilder<?>> type) {
+                if (type == FetchUserBuilder.class) return new FetchUserBuilder();
+                if (type == FetchConfigBuilder.class) return new FetchConfigBuilder();
+                if (type == EnrichBuilder.class) return new EnrichBuilder();
+                if (type == FetchOrdersBuilder.class) return new FetchOrdersBuilder();
+                if (type == AssembleBuilder.class) return new AssembleBuilder();
+                throw new IllegalArgumentException("Unknown builder: " + type);
+            }
+        };
+
+        DagCompiler compiler = new DagCompiler();
+        dag = compiler.compile(BenchmarkApi.class);
+        executor = new DagExecutor(factory);
+    }
+
+    @Benchmark
+    public byte[] endToEnd() throws IOException {
+        // 1. Route matching
+        RouteTrie.RouteMatch match = routeTrie.find("GET", "/api/users/42/dashboard");
+
+        // 2. Context creation (using mock request)
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users/42/dashboard");
+        request.addHeader("Accept", "application/json");
+        request.addHeader("Authorization", "Bearer tok-123");
+        LoomHttpContextImpl httpCtx = new LoomHttpContextImpl(
+                request, mockResponse, codec, match.pathVariables(), 10_485_760);
+
+        // 3. Build a lightweight BuilderContext from the HTTP context
+        StubBuilderContext builderCtx = new StubBuilderContext(
+                httpCtx.getHttpMethod(), httpCtx.getRequestPath(), match.pathVariables());
+
+        // 4. DAG execution
+        Object result = executor.execute(dag, builderCtx);
+
+        // 5. JSON serialization
+        return codec.writeValueAsBytes(result);
+    }
+
+    // ── Minimal BuilderContext ──
+
+    static class StubBuilderContext implements BuilderContext {
+        private final String method;
+        private final String path;
+        private final Map<String, String> pathVars;
+        private Object[] results;
+        private Map<Class<?>, Integer> typeIndexMap;
+        private Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap;
+        private static final Object NULL_SENTINEL = new Object();
+
+        StubBuilderContext(String method, String path, Map<String, String> pathVars) {
+            this.method = method;
+            this.path = path;
+            this.pathVars = pathVars;
+        }
+
+        @Override public <T> T getRequestBody(Class<T> type) { return null; }
+        @Override public String getPathVariable(String name) { return pathVars.get(name); }
+        @Override public String getQueryParam(String name) { return null; }
+        @Override public String getHeader(String name) { return null; }
+        @Override public String getHttpMethod() { return method; }
+        @Override public String getRequestPath() { return path; }
+        @Override public Map<String, String> getPathVariables() { return pathVars; }
+        @Override public Map<String, List<String>> getQueryParams() { return Map.of(); }
+        @Override public Map<String, List<String>> getHeaders() { return Map.of(); }
+        @Override public byte[] getRawRequestBody() { return null; }
+        @Override public ServiceAccessor service(String name) { return null; }
+        @Override public void setAttribute(String key, Object value) {}
+        @Override @SuppressWarnings("unchecked")
+        public <T> T getAttribute(String key, Class<T> type) { return null; }
+        @Override public Map<String, Object> getAttributes() { return Map.of(); }
+
+        @Override
+        public void initResultStorage(int nodeCount,
+                                      Map<Class<?>, Integer> typeIndexMap,
+                                      Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap) {
+            this.results = new Object[nodeCount];
+            this.typeIndexMap = typeIndexMap;
+            this.builderIndexMap = builderIndexMap;
+        }
+
+        @Override
+        public void storeResult(Class<? extends LoomBuilder<?>> builderClass, Class<?> outputType, Object result) {
+            Object stored = result != null ? result : NULL_SENTINEL;
+            Integer index = builderIndexMap.get(builderClass);
+            if (index != null) results[index] = stored;
+        }
+
+        @Override @SuppressWarnings("unchecked")
+        public <T> T getDependency(Class<T> outputType) {
+            Integer index = typeIndexMap.get(outputType);
+            if (index == null || results[index] == null) {
+                throw new LoomDependencyResolutionException(outputType.getSimpleName(), List.of(), List.of());
+            }
+            Object r = results[index];
+            return r == NULL_SENTINEL ? null : (T) r;
+        }
+
+        @Override @SuppressWarnings("unchecked")
+        public <T> T getResultOf(Class<? extends LoomBuilder<T>> builderClass) {
+            Integer index = builderIndexMap.get(builderClass);
+            if (index == null || results[index] == null) {
+                throw new LoomDependencyResolutionException("builder:" + builderClass.getSimpleName(), List.of(), List.of());
+            }
+            Object r = results[index];
+            return r == NULL_SENTINEL ? null : (T) r;
+        }
+
+        @Override @SuppressWarnings("unchecked")
+        public <T> Optional<T> getOptionalDependency(Class<T> outputType) {
+            Integer index = typeIndexMap != null ? typeIndexMap.get(outputType) : null;
+            if (index == null) return Optional.empty();
+            Object v = results[index];
+            return v == null ? Optional.empty() : Optional.ofNullable(v == NULL_SENTINEL ? null : (T) v);
+        }
+
+        @Override @SuppressWarnings("unchecked")
+        public <T> Optional<T> getOptionalResultOf(Class<? extends LoomBuilder<T>> builderClass) {
+            Integer index = builderIndexMap != null ? builderIndexMap.get(builderClass) : null;
+            if (index == null) return Optional.empty();
+            Object v = results[index];
+            return v == null ? Optional.empty() : Optional.ofNullable(v == NULL_SENTINEL ? null : (T) v);
+        }
+    }
+}

--- a/loom-benchmark/src/main/java/io/loom/benchmark/JsonCodecBenchmark.java
+++ b/loom-benchmark/src/main/java/io/loom/benchmark/JsonCodecBenchmark.java
@@ -1,0 +1,63 @@
+package io.loom.benchmark;
+
+import io.loom.core.codec.DslJsonCodec;
+import io.loom.core.codec.JsonCodec;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode({Mode.Throughput, Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class JsonCodecBenchmark {
+
+    // Typical API response POJO (~500 bytes serialized)
+    public record Product(
+        String id,
+        String name,
+        String description,
+        double price,
+        String currency,
+        int stockCount,
+        List<String> tags,
+        Dimensions dimensions
+    ) {}
+
+    public record Dimensions(double width, double height, double depth, String unit) {}
+
+    private JsonCodec codec;
+    private Product product;
+    private byte[] serializedBytes;
+
+    @Setup
+    public void setup() throws IOException {
+        codec = new DslJsonCodec();
+        product = new Product(
+            "prod-12345",
+            "Premium Wireless Headphones",
+            "High-fidelity audio with active noise cancellation and 30-hour battery life",
+            299.99,
+            "USD",
+            1500,
+            List.of("electronics", "audio", "wireless", "premium"),
+            new Dimensions(18.5, 20.0, 8.0, "cm")
+        );
+        serializedBytes = codec.writeValueAsBytes(product);
+    }
+
+    @Benchmark
+    public byte[] serialize() throws IOException {
+        return codec.writeValueAsBytes(product);
+    }
+
+    @Benchmark
+    public Product deserialize() throws IOException {
+        return codec.readValue(serializedBytes, Product.class);
+    }
+}

--- a/loom-benchmark/src/main/java/io/loom/benchmark/RouteTrieBenchmark.java
+++ b/loom-benchmark/src/main/java/io/loom/benchmark/RouteTrieBenchmark.java
@@ -1,0 +1,74 @@
+package io.loom.benchmark;
+
+import io.loom.core.model.ApiDefinition;
+import io.loom.starter.web.RouteTrie;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode({Mode.Throughput, Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class RouteTrieBenchmark {
+
+    private RouteTrie trie;
+
+    private static ApiDefinition api(String method, String path) {
+        return new ApiDefinition(method, path, null, null, null, null,
+                null, null, null, null, null, null, null, null, null);
+    }
+
+    @Setup
+    public void setup() {
+        trie = new RouteTrie();
+
+        // 50 routes: mix of static and parameterized
+        String[] resources = {"users", "products", "orders", "reviews", "payments",
+                "invoices", "shipments", "categories", "tags", "comments"};
+        String[] actions = {"profile", "settings", "history", "details", "summary"};
+
+        for (String resource : resources) {
+            trie.insert(api("GET", "/api/v1/" + resource));
+            trie.insert(api("POST", "/api/v1/" + resource));
+            trie.insert(api("GET", "/api/v1/" + resource + "/{id}"));
+        }
+
+        for (int i = 0; i < resources.length; i++) {
+            String action = actions[i % actions.length];
+            trie.insert(api("GET", "/api/v1/" + resources[i] + "/{id}/" + action));
+        }
+
+        for (int i = 0; i < 10; i++) {
+            trie.insert(api("GET", "/api/v2/resource" + i + "/{parentId}/child/{childId}"));
+        }
+    }
+
+    @Benchmark
+    public RouteTrie.RouteMatch findStaticRoute() {
+        return trie.find("GET", "/api/v1/users");
+    }
+
+    @Benchmark
+    public RouteTrie.RouteMatch findSingleParam() {
+        return trie.find("GET", "/api/v1/products/42");
+    }
+
+    @Benchmark
+    public RouteTrie.RouteMatch findDoubleParam() {
+        return trie.find("GET", "/api/v2/resource5/100/child/200");
+    }
+
+    @Benchmark
+    public RouteTrie.RouteMatch findDeepParamPath() {
+        return trie.find("GET", "/api/v1/users/42/profile");
+    }
+
+    @Benchmark
+    public RouteTrie.RouteMatch findMiss() {
+        return trie.find("GET", "/api/v1/nonexistent/42");
+    }
+}

--- a/loom-core/src/main/java/io/loom/core/builder/BuilderContext.java
+++ b/loom-core/src/main/java/io/loom/core/builder/BuilderContext.java
@@ -34,4 +34,25 @@ public interface BuilderContext {
 
     // Result storage (used by DagExecutor)
     void storeResult(Class<? extends LoomBuilder<?>> builderClass, Class<?> outputType, Object result);
+
+    /**
+     * Called once by {@link io.loom.core.engine.DagExecutor} before DAG execution to initialize
+     * pre-indexed, array-based result storage. The executor passes the compiled index maps so that
+     * {@link #storeResult}, {@link #getDependency}, {@link #getResultOf}, and their optional
+     * variants can resolve results by array index instead of concurrent map lookup.
+     *
+     * <p>The default implementation is a no-op for backward compatibility with test stubs that
+     * use their own storage. Any {@code BuilderContext} implementation used with
+     * {@code DagExecutor} in production <b>must</b> override this method to allocate the
+     * result array and store the index maps; otherwise dependency resolution will fail at runtime.
+     *
+     * @param nodeCount       total number of nodes in the DAG (array size)
+     * @param typeIndexMap    output type → array index (for type-based lookups)
+     * @param builderIndexMap builder class → array index (for builder-class-based lookups)
+     */
+    default void initResultStorage(int nodeCount,
+                                   Map<Class<?>, Integer> typeIndexMap,
+                                   Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap) {
+        // no-op default for backward compatibility
+    }
 }

--- a/loom-core/src/main/java/io/loom/core/engine/Dag.java
+++ b/loom-core/src/main/java/io/loom/core/engine/Dag.java
@@ -9,13 +9,21 @@ public class Dag {
     private final Map<Class<? extends LoomBuilder<?>>, DagNode> nodes;
     private final List<DagNode> topologicalOrder;
     private final DagNode terminalNode;
+    private final int terminalNodeIndex;
+    private final Map<Class<?>, Integer> typeIndexMap;
+    private final Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap;
 
     public Dag(Map<Class<? extends LoomBuilder<?>>, DagNode> nodes,
                List<DagNode> topologicalOrder,
-               DagNode terminalNode) {
+               DagNode terminalNode,
+               Map<Class<?>, Integer> typeIndexMap,
+               Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap) {
         this.nodes = Collections.unmodifiableMap(new LinkedHashMap<>(nodes));
         this.topologicalOrder = Collections.unmodifiableList(new ArrayList<>(topologicalOrder));
         this.terminalNode = terminalNode;
+        this.terminalNodeIndex = terminalNode.index();
+        this.typeIndexMap = Map.copyOf(typeIndexMap);
+        this.builderIndexMap = Map.copyOf(builderIndexMap);
     }
 
     public Map<Class<? extends LoomBuilder<?>>, DagNode> getNodes() {
@@ -30,11 +38,27 @@ public class Dag {
         return terminalNode;
     }
 
+    public int terminalNodeIndex() {
+        return terminalNodeIndex;
+    }
+
     public DagNode getNode(Class<? extends LoomBuilder<?>> builderClass) {
         return nodes.get(builderClass);
     }
 
     public int size() {
         return nodes.size();
+    }
+
+    public int nodeCount() {
+        return nodes.size();
+    }
+
+    public Map<Class<?>, Integer> typeIndexMap() {
+        return typeIndexMap;
+    }
+
+    public Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap() {
+        return builderIndexMap;
     }
 }

--- a/loom-core/src/main/java/io/loom/core/engine/DagExecutor.java
+++ b/loom-core/src/main/java/io/loom/core/engine/DagExecutor.java
@@ -108,7 +108,9 @@ public class DagExecutor {
 
             context.storeResult(node.builderClass(), node.outputType(), result);
 
-            log.debug("[Loom] Node '{}' completed successfully", node.name());
+            if (log.isDebugEnabled()) {
+                log.debug("[Loom] Node '{}' completed successfully", node.name());
+            }
             return BuilderResult.success(result);
         } catch (Exception e) {
             log.error("[Loom] Required builder '{}' failed: {}", node.name(), e.getMessage(), e);

--- a/loom-core/src/main/java/io/loom/core/engine/DagNode.java
+++ b/loom-core/src/main/java/io/loom/core/engine/DagNode.java
@@ -8,8 +8,18 @@ public record DagNode(
     Set<Class<? extends LoomBuilder<?>>> dependsOn,
     boolean required,
     long timeoutMs,
-    Class<?> outputType
+    Class<?> outputType,
+    int index,
+    int[] dependencyIndices
 ) {
+    public DagNode(Class<? extends LoomBuilder<?>> builderClass,
+                   Set<Class<? extends LoomBuilder<?>>> dependsOn,
+                   boolean required,
+                   long timeoutMs,
+                   Class<?> outputType) {
+        this(builderClass, dependsOn, required, timeoutMs, outputType, -1, new int[0]);
+    }
+
     public String name() {
         return builderClass.getSimpleName();
     }

--- a/loom-core/src/main/java/io/loom/core/exception/LoomServiceClientException.java
+++ b/loom-core/src/main/java/io/loom/core/exception/LoomServiceClientException.java
@@ -24,4 +24,12 @@ public class LoomServiceClientException extends LoomException {
         this.serviceName = serviceName;
         this.statusCode = -1;
     }
+
+    /**
+     * Transport failures (statusCode == -1) and server errors (5xx) are retryable.
+     * Client errors (4xx) are never retryable — the same request will produce the same result.
+     */
+    public boolean isRetryable() {
+        return statusCode == -1 || statusCode >= 500;
+    }
 }

--- a/loom-core/src/main/java/io/loom/core/service/RouteInvoker.java
+++ b/loom-core/src/main/java/io/loom/core/service/RouteInvoker.java
@@ -24,4 +24,19 @@ public interface RouteInvoker {
     <T> T delete(Class<T> responseType);
 
     <T> T patch(Class<T> responseType);
+
+    /** Returns full response metadata without throwing on 4xx/5xx. */
+    <T> ServiceResponse<T> getResponse(Class<T> responseType);
+
+    /** Returns full response metadata without throwing on 4xx/5xx. */
+    <T> ServiceResponse<T> postResponse(Class<T> responseType);
+
+    /** Returns full response metadata without throwing on 4xx/5xx. */
+    <T> ServiceResponse<T> putResponse(Class<T> responseType);
+
+    /** Returns full response metadata without throwing on 4xx/5xx. */
+    <T> ServiceResponse<T> deleteResponse(Class<T> responseType);
+
+    /** Returns full response metadata without throwing on 4xx/5xx. */
+    <T> ServiceResponse<T> patchResponse(Class<T> responseType);
 }

--- a/loom-core/src/main/java/io/loom/core/service/ServiceClient.java
+++ b/loom-core/src/main/java/io/loom/core/service/ServiceClient.java
@@ -17,4 +17,22 @@ public interface ServiceClient {
 
     <T> T patch(String path, Object body, Class<T> responseType);
     <T> T patch(String path, Object body, Class<T> responseType, Map<String, String> headers);
+
+    /**
+     * Raw proxy for passthrough mode — returns raw bytes with full response metadata.
+     * Does not throw on 4xx/5xx; upstream status is captured in the response.
+     */
+    default ServiceResponse<byte[]> proxy(String method, String path, byte[] body, Map<String, String> headers) {
+        throw new UnsupportedOperationException("proxy() not implemented by " + getClass().getSimpleName());
+    }
+
+    /**
+     * Typed exchange for builder mode — returns typed data with full response metadata.
+     * Does not throw on 4xx/5xx; upstream status is captured in the response.
+     * Transport failures still throw LoomServiceClientException.
+     */
+    default <T> ServiceResponse<T> exchange(String method, String path, Object body,
+                                             Class<T> responseType, Map<String, String> headers) {
+        throw new UnsupportedOperationException("exchange() not implemented by " + getClass().getSimpleName());
+    }
 }

--- a/loom-core/src/main/java/io/loom/core/service/ServiceResponse.java
+++ b/loom-core/src/main/java/io/loom/core/service/ServiceResponse.java
@@ -1,0 +1,35 @@
+package io.loom.core.service;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unified response wrapper carrying typed data, HTTP status, headers, and raw body.
+ * Used in both builder mode (typed exchange without throwing on 4xx/5xx) and
+ * passthrough mode (raw byte forwarding with full response metadata).
+ *
+ * @param data        deserialized body (null on error or for raw byte mode)
+ * @param statusCode  HTTP status code from upstream
+ * @param headers     response headers from upstream
+ * @param rawBody     raw response bytes (always available)
+ * @param contentType response Content-Type from upstream
+ */
+public record ServiceResponse<T>(
+        T data,
+        int statusCode,
+        Map<String, List<String>> headers,
+        byte[] rawBody,
+        String contentType
+) {
+    public boolean isSuccessful() {
+        return statusCode >= 200 && statusCode < 300;
+    }
+
+    public boolean isClientError() {
+        return statusCode >= 400 && statusCode < 500;
+    }
+
+    public boolean isServerError() {
+        return statusCode >= 500;
+    }
+}

--- a/loom-core/src/test/java/io/loom/core/engine/DagExecutorTest.java
+++ b/loom-core/src/test/java/io/loom/core/engine/DagExecutorTest.java
@@ -10,7 +10,6 @@ import io.loom.core.service.ServiceAccessor;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.*;
@@ -21,7 +20,7 @@ class DagExecutorTest {
     // ── Stub BuilderContext that supports array-based storage ──
 
     static class StubBuilderContext implements BuilderContext {
-        private final Map<String, Object> attributes = new ConcurrentHashMap<>();
+        private final Map<String, Object> attributes = new HashMap<>();
         private final Map<String, String> pathVars;
 
         // Array-based result storage

--- a/loom-core/src/test/java/io/loom/core/engine/DagExecutorTest.java
+++ b/loom-core/src/test/java/io/loom/core/engine/DagExecutorTest.java
@@ -18,13 +18,17 @@ import static org.mockito.Mockito.*;
 
 class DagExecutorTest {
 
-    // ── Stub BuilderContext that actually stores and resolves dependencies ──
+    // ── Stub BuilderContext that supports array-based storage ──
 
     static class StubBuilderContext implements BuilderContext {
-        private final ConcurrentHashMap<Class<?>, Object> resultsByType = new ConcurrentHashMap<>();
-        private final ConcurrentHashMap<Class<? extends LoomBuilder<?>>, Object> resultsByBuilder = new ConcurrentHashMap<>();
         private final Map<String, Object> attributes = new ConcurrentHashMap<>();
         private final Map<String, String> pathVars;
+
+        // Array-based result storage
+        private Object[] results;
+        private Map<Class<?>, Integer> typeIndexMap;
+        private Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap;
+        private static final Object NULL_SENTINEL = new Object();
 
         StubBuilderContext() { this(Map.of()); }
         StubBuilderContext(Map<String, String> pathVars) { this.pathVars = pathVars; }
@@ -45,46 +49,121 @@ class DagExecutorTest {
         public <T> T getAttribute(String key, Class<T> type) { return (T) attributes.get(key); }
         @Override public Map<String, Object> getAttributes() { return attributes; }
 
-        private static final Object NULL_SENTINEL = new Object();
+        @Override
+        public void initResultStorage(int nodeCount,
+                                      Map<Class<?>, Integer> typeIndexMap,
+                                      Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap) {
+            this.results = new Object[nodeCount];
+            this.typeIndexMap = typeIndexMap;
+            this.builderIndexMap = builderIndexMap;
+        }
 
         @Override
         public void storeResult(Class<? extends LoomBuilder<?>> builderClass, Class<?> outputType, Object result) {
             Object stored = result != null ? result : NULL_SENTINEL;
-            resultsByBuilder.put(builderClass, stored);
-            resultsByType.put(outputType, stored);
+            Integer index = builderIndexMap.get(builderClass);
+            if (index != null) {
+                results[index] = stored;
+            }
         }
 
         @Override @SuppressWarnings("unchecked")
         public <T> T getDependency(Class<T> outputType) {
-            Object result = resultsByType.get(outputType);
-            if (result == null) throw new LoomDependencyResolutionException(
-                    outputType.getSimpleName(),
-                    resultsByType.keySet().stream().map(Class::getSimpleName).toList(),
-                    resultsByBuilder.keySet().stream().map(Class::getSimpleName).toList());
+            Integer index = typeIndexMap.get(outputType);
+            if (index == null || results[index] == null) {
+                throw new LoomDependencyResolutionException(
+                        outputType.getSimpleName(),
+                        availableTypeNames(),
+                        availableBuilderNames());
+            }
+            Object result = results[index];
             return result == NULL_SENTINEL ? null : (T) result;
         }
 
         @Override @SuppressWarnings("unchecked")
         public <T> T getResultOf(Class<? extends LoomBuilder<T>> builderClass) {
-            Object result = resultsByBuilder.get(builderClass);
-            if (result == null) throw new LoomDependencyResolutionException(
-                    "builder:" + builderClass.getSimpleName(),
-                    resultsByType.keySet().stream().map(Class::getSimpleName).toList(),
-                    resultsByBuilder.keySet().stream().map(Class::getSimpleName).toList());
+            Integer index = builderIndexMap.get(builderClass);
+            if (index == null || results[index] == null) {
+                throw new LoomDependencyResolutionException(
+                        "builder:" + builderClass.getSimpleName(),
+                        availableTypeNames(),
+                        availableBuilderNames());
+            }
+            Object result = results[index];
             return result == NULL_SENTINEL ? null : (T) result;
         }
 
         @Override @SuppressWarnings("unchecked")
         public <T> Optional<T> getOptionalDependency(Class<T> outputType) {
-            Object value = resultsByType.get(outputType);
+            Integer index = typeIndexMap != null ? typeIndexMap.get(outputType) : null;
+            if (index == null) return Optional.empty();
+            Object value = results[index];
             return value == null ? Optional.empty() : Optional.ofNullable(value == NULL_SENTINEL ? null : (T) value);
         }
 
         @Override @SuppressWarnings("unchecked")
         public <T> Optional<T> getOptionalResultOf(Class<? extends LoomBuilder<T>> builderClass) {
-            Object value = resultsByBuilder.get(builderClass);
+            Integer index = builderIndexMap != null ? builderIndexMap.get(builderClass) : null;
+            if (index == null) return Optional.empty();
+            Object value = results[index];
             return value == null ? Optional.empty() : Optional.ofNullable(value == NULL_SENTINEL ? null : (T) value);
         }
+
+        private List<String> availableTypeNames() {
+            if (typeIndexMap == null) return List.of();
+            List<String> names = new ArrayList<>();
+            for (var entry : typeIndexMap.entrySet()) {
+                if (results[entry.getValue()] != null) {
+                    names.add(entry.getKey().getSimpleName());
+                }
+            }
+            return names;
+        }
+
+        private List<String> availableBuilderNames() {
+            if (builderIndexMap == null) return List.of();
+            List<String> names = new ArrayList<>();
+            for (var entry : builderIndexMap.entrySet()) {
+                if (results[entry.getValue()] != null) {
+                    names.add(entry.getKey().getSimpleName());
+                }
+            }
+            return names;
+        }
+    }
+
+    // ── Helper: build an indexed Dag from a list of DagNode in topological order ──
+
+    static Dag buildDag(List<DagNode> topoOrder, DagNode terminal) {
+        Map<Class<? extends LoomBuilder<?>>, Integer> builderToIndex = new HashMap<>();
+        List<DagNode> indexedOrder = new ArrayList<>(topoOrder.size());
+
+        for (int i = 0; i < topoOrder.size(); i++) {
+            DagNode orig = topoOrder.get(i);
+            builderToIndex.put(orig.builderClass(), i);
+
+            int[] depIndices = new int[orig.dependsOn().size()];
+            int di = 0;
+            for (var dep : orig.dependsOn()) {
+                depIndices[di++] = builderToIndex.get(dep);
+            }
+
+            indexedOrder.add(new DagNode(orig.builderClass(), orig.dependsOn(),
+                    orig.required(), orig.timeoutMs(), orig.outputType(), i, depIndices));
+        }
+
+        Map<Class<? extends LoomBuilder<?>>, DagNode> nodesMap = new LinkedHashMap<>();
+        Map<Class<?>, Integer> typeIndexMap = new HashMap<>();
+        Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap = new HashMap<>();
+
+        for (DagNode node : indexedOrder) {
+            nodesMap.put(node.builderClass(), node);
+            typeIndexMap.put(node.outputType(), node.index());
+            builderIndexMap.put(node.builderClass(), node.index());
+        }
+
+        DagNode indexedTerminal = nodesMap.get(terminal.builderClass());
+        return new Dag(nodesMap, indexedOrder, indexedTerminal, typeIndexMap, builderIndexMap);
     }
 
     // ── Simple types + builders ──
@@ -108,14 +187,6 @@ class DagExecutorTest {
     }
 
     // ── Complex 4-level DAG types ──
-    //
-    //  Level 0:  FetchUser ──────────────────────┐
-    //            FetchConfig ─────────────┐      │
-    //  Level 1:  EnrichUser (User+Config) ┤      │
-    //            FetchOrders (User) ───────┤      │
-    //  Level 2:  ScoreUser (EnrichedUser+Orders)──┤
-    //  Level 3:  BuildDashboard (User+EnrichedUser+Score+Orders) ← terminal
-    //
 
     record User(String id, String name) {}
     record Config(String region) {}
@@ -205,14 +276,11 @@ class DagExecutorTest {
         doReturn(new FastBuilder()).when(factory).createBuilderUntyped(FastBuilder.class);
         doReturn(new AssemblerBuilder()).when(factory).createBuilderUntyped(AssemblerBuilder.class);
 
-        Map<Class<? extends LoomBuilder<?>>, DagNode> nodes = new LinkedHashMap<>();
-        nodes.put(FastBuilder.class, new DagNode(FastBuilder.class, Set.of(), true, 5000, String.class));
-        nodes.put(AssemblerBuilder.class, new DagNode(AssemblerBuilder.class,
-                Set.of(FastBuilder.class), true, 5000, FinalResult.class));
+        DagNode fast = new DagNode(FastBuilder.class, Set.of(), true, 5000, String.class);
+        DagNode assembler = new DagNode(AssemblerBuilder.class,
+                Set.of(FastBuilder.class), true, 5000, FinalResult.class);
 
-        DagNode terminal = nodes.get(AssemblerBuilder.class);
-        List<DagNode> topoOrder = List.of(nodes.get(FastBuilder.class), terminal);
-        Dag dag = new Dag(nodes, topoOrder, terminal);
+        Dag dag = buildDag(List.of(fast, assembler), assembler);
 
         DagExecutor executor = new DagExecutor(factory);
         Object result = executor.execute(dag, new StubBuilderContext());
@@ -246,16 +314,12 @@ class DagExecutorTest {
         doReturn(parallelBuilder2).when(factory).createBuilderUntyped(SlowBuilder.class);
         doReturn(new AssemblerBuilder()).when(factory).createBuilderUntyped(AssemblerBuilder.class);
 
-        Map<Class<? extends LoomBuilder<?>>, DagNode> nodes = new LinkedHashMap<>();
-        nodes.put(FastBuilder.class, new DagNode(FastBuilder.class, Set.of(), true, 5000, String.class));
-        nodes.put(SlowBuilder.class, new DagNode(SlowBuilder.class, Set.of(), true, 5000, Integer.class));
-        nodes.put(AssemblerBuilder.class, new DagNode(AssemblerBuilder.class,
-                Set.of(FastBuilder.class, SlowBuilder.class), true, 5000, FinalResult.class));
+        DagNode fast = new DagNode(FastBuilder.class, Set.of(), true, 5000, String.class);
+        DagNode slow = new DagNode(SlowBuilder.class, Set.of(), true, 5000, Integer.class);
+        DagNode assembler = new DagNode(AssemblerBuilder.class,
+                Set.of(FastBuilder.class, SlowBuilder.class), true, 5000, FinalResult.class);
 
-        DagNode terminal = nodes.get(AssemblerBuilder.class);
-        List<DagNode> topoOrder = List.of(
-                nodes.get(FastBuilder.class), nodes.get(SlowBuilder.class), terminal);
-        Dag dag = new Dag(nodes, topoOrder, terminal);
+        Dag dag = buildDag(List.of(fast, slow, assembler), assembler);
 
         DagExecutor executor = new DagExecutor(factory);
         Object result = executor.execute(dag, new StubBuilderContext());
@@ -274,36 +338,22 @@ class DagExecutorTest {
         doReturn(new ScoreUserBuilder()).when(factory).createBuilderUntyped(ScoreUserBuilder.class);
         doReturn(new BuildDashboardBuilder()).when(factory).createBuilderUntyped(BuildDashboardBuilder.class);
 
-        Map<Class<? extends LoomBuilder<?>>, DagNode> nodes = new LinkedHashMap<>();
-        nodes.put(FetchUserBuilder.class,
-                new DagNode(FetchUserBuilder.class, Set.of(), true, 5000, User.class));
-        nodes.put(FetchConfigBuilder.class,
-                new DagNode(FetchConfigBuilder.class, Set.of(), true, 5000, Config.class));
-        nodes.put(EnrichUserBuilder.class,
-                new DagNode(EnrichUserBuilder.class,
-                        Set.of(FetchUserBuilder.class, FetchConfigBuilder.class), true, 5000, EnrichedUser.class));
-        nodes.put(FetchOrdersBuilder.class,
-                new DagNode(FetchOrdersBuilder.class,
-                        Set.of(FetchUserBuilder.class), true, 5000, OrderList.class));
-        nodes.put(ScoreUserBuilder.class,
-                new DagNode(ScoreUserBuilder.class,
-                        Set.of(EnrichUserBuilder.class, FetchOrdersBuilder.class), true, 5000, UserScore.class));
-        nodes.put(BuildDashboardBuilder.class,
-                new DagNode(BuildDashboardBuilder.class,
-                        Set.of(FetchUserBuilder.class, EnrichUserBuilder.class,
-                                FetchOrdersBuilder.class, ScoreUserBuilder.class),
-                        true, 5000, Dashboard.class));
+        DagNode fetchUser = new DagNode(FetchUserBuilder.class, Set.of(), true, 5000, User.class);
+        DagNode fetchConfig = new DagNode(FetchConfigBuilder.class, Set.of(), true, 5000, Config.class);
+        DagNode enrichUser = new DagNode(EnrichUserBuilder.class,
+                Set.of(FetchUserBuilder.class, FetchConfigBuilder.class), true, 5000, EnrichedUser.class);
+        DagNode fetchOrders = new DagNode(FetchOrdersBuilder.class,
+                Set.of(FetchUserBuilder.class), true, 5000, OrderList.class);
+        DagNode scoreUser = new DagNode(ScoreUserBuilder.class,
+                Set.of(EnrichUserBuilder.class, FetchOrdersBuilder.class), true, 5000, UserScore.class);
+        DagNode buildDashboard = new DagNode(BuildDashboardBuilder.class,
+                Set.of(FetchUserBuilder.class, EnrichUserBuilder.class,
+                        FetchOrdersBuilder.class, ScoreUserBuilder.class),
+                true, 5000, Dashboard.class);
 
-        DagNode terminal = nodes.get(BuildDashboardBuilder.class);
-        List<DagNode> topoOrder = List.of(
-                nodes.get(FetchUserBuilder.class),
-                nodes.get(FetchConfigBuilder.class),
-                nodes.get(EnrichUserBuilder.class),
-                nodes.get(FetchOrdersBuilder.class),
-                nodes.get(ScoreUserBuilder.class),
-                terminal
-        );
-        Dag dag = new Dag(nodes, topoOrder, terminal);
+        Dag dag = buildDag(
+                List.of(fetchUser, fetchConfig, enrichUser, fetchOrders, scoreUser, buildDashboard),
+                buildDashboard);
 
         DagExecutor executor = new DagExecutor(factory);
         Object result = executor.execute(dag, new StubBuilderContext());
@@ -324,16 +374,12 @@ class DagExecutorTest {
         doReturn(new TagBuilderB()).when(factory).createBuilderUntyped(TagBuilderB.class);
         doReturn(new MergeTagsBuilder()).when(factory).createBuilderUntyped(MergeTagsBuilder.class);
 
-        Map<Class<? extends LoomBuilder<?>>, DagNode> nodes = new LinkedHashMap<>();
-        nodes.put(TagBuilderA.class, new DagNode(TagBuilderA.class, Set.of(), true, 5000, String.class));
-        nodes.put(TagBuilderB.class, new DagNode(TagBuilderB.class, Set.of(), true, 5000, String.class));
-        nodes.put(MergeTagsBuilder.class, new DagNode(MergeTagsBuilder.class,
-                Set.of(TagBuilderA.class, TagBuilderB.class), true, 5000, MergedTags.class));
+        DagNode tagA = new DagNode(TagBuilderA.class, Set.of(), true, 5000, String.class);
+        DagNode tagB = new DagNode(TagBuilderB.class, Set.of(), true, 5000, String.class);
+        DagNode merge = new DagNode(MergeTagsBuilder.class,
+                Set.of(TagBuilderA.class, TagBuilderB.class), true, 5000, MergedTags.class);
 
-        DagNode terminal = nodes.get(MergeTagsBuilder.class);
-        List<DagNode> topoOrder = List.of(
-                nodes.get(TagBuilderA.class), nodes.get(TagBuilderB.class), terminal);
-        Dag dag = new Dag(nodes, topoOrder, terminal);
+        Dag dag = buildDag(List.of(tagA, tagB, merge), merge);
 
         DagExecutor executor = new DagExecutor(factory);
         Object result = executor.execute(dag, new StubBuilderContext());
@@ -351,16 +397,12 @@ class DagExecutorTest {
         doReturn(new FailingBuilder()).when(factory).createBuilderUntyped(FailingBuilder.class);
         doReturn(new CollectorBuilder()).when(factory).createBuilderUntyped(CollectorBuilder.class);
 
-        Map<Class<? extends LoomBuilder<?>>, DagNode> nodes = new LinkedHashMap<>();
-        nodes.put(SlowBuilder.class, new DagNode(SlowBuilder.class, Set.of(), true, 5000, Integer.class));
-        nodes.put(FailingBuilder.class, new DagNode(FailingBuilder.class, Set.of(), false, 5000, String.class));
-        nodes.put(CollectorBuilder.class, new DagNode(CollectorBuilder.class,
-                Set.of(SlowBuilder.class, FailingBuilder.class), true, 5000, OptionalResult.class));
+        DagNode slow = new DagNode(SlowBuilder.class, Set.of(), true, 5000, Integer.class);
+        DagNode failing = new DagNode(FailingBuilder.class, Set.of(), false, 5000, String.class);
+        DagNode collector = new DagNode(CollectorBuilder.class,
+                Set.of(SlowBuilder.class, FailingBuilder.class), true, 5000, OptionalResult.class);
 
-        DagNode terminal = nodes.get(CollectorBuilder.class);
-        List<DagNode> topoOrder = List.of(
-                nodes.get(SlowBuilder.class), nodes.get(FailingBuilder.class), terminal);
-        Dag dag = new Dag(nodes, topoOrder, terminal);
+        Dag dag = buildDag(List.of(slow, failing, collector), collector);
 
         DagExecutor executor = new DagExecutor(factory);
         Object result = executor.execute(dag, new StubBuilderContext());
@@ -372,10 +414,81 @@ class DagExecutorTest {
     }
 
     @Test
+    void shouldExecuteSingleNodeDag() {
+        BuilderFactory factory = mock(BuilderFactory.class);
+        doReturn(new AssemblerBuilder()).when(factory).createBuilderUntyped(AssemblerBuilder.class);
+
+        DagNode assembler = new DagNode(AssemblerBuilder.class, Set.of(), true, 5000, FinalResult.class);
+        Dag dag = buildDag(List.of(assembler), assembler);
+
+        DagExecutor executor = new DagExecutor(factory);
+        Object result = executor.execute(dag, new StubBuilderContext());
+
+        assertThat(result).isInstanceOf(FinalResult.class);
+        assertThat(((FinalResult) result).value).isEqualTo("assembled");
+    }
+
+    // ── Diamond dependency types ──
+
+    record DiamondA(String value) {}
+    record DiamondB(int value) {}
+    record DiamondC(String combined) {}
+    record DiamondResult(String a, int b, String c) {}
+
+    static class DiamondABuilder implements LoomBuilder<DiamondA> {
+        public DiamondA build(BuilderContext ctx) { return new DiamondA("alpha"); }
+    }
+    static class DiamondBBuilder implements LoomBuilder<DiamondB> {
+        public DiamondB build(BuilderContext ctx) { return new DiamondB(99); }
+    }
+    static class DiamondCBuilder implements LoomBuilder<DiamondC> {
+        public DiamondC build(BuilderContext ctx) {
+            DiamondA a = ctx.getDependency(DiamondA.class);
+            DiamondB b = ctx.getDependency(DiamondB.class);
+            return new DiamondC(a.value() + "-" + b.value());
+        }
+    }
+    static class DiamondTerminalBuilder implements LoomBuilder<DiamondResult> {
+        public DiamondResult build(BuilderContext ctx) {
+            DiamondA a = ctx.getDependency(DiamondA.class);
+            DiamondB b = ctx.getDependency(DiamondB.class);
+            DiamondC c = ctx.getDependency(DiamondC.class);
+            return new DiamondResult(a.value(), b.value(), c.combined());
+        }
+    }
+
+    @Test
+    void shouldExecuteDiamondDependencyPattern() {
+        BuilderFactory factory = mock(BuilderFactory.class);
+        doReturn(new DiamondABuilder()).when(factory).createBuilderUntyped(DiamondABuilder.class);
+        doReturn(new DiamondBBuilder()).when(factory).createBuilderUntyped(DiamondBBuilder.class);
+        doReturn(new DiamondCBuilder()).when(factory).createBuilderUntyped(DiamondCBuilder.class);
+        doReturn(new DiamondTerminalBuilder()).when(factory).createBuilderUntyped(DiamondTerminalBuilder.class);
+
+        DagNode nodeA = new DagNode(DiamondABuilder.class, Set.of(), true, 5000, DiamondA.class);
+        DagNode nodeB = new DagNode(DiamondBBuilder.class, Set.of(), true, 5000, DiamondB.class);
+        DagNode nodeC = new DagNode(DiamondCBuilder.class,
+                Set.of(DiamondABuilder.class, DiamondBBuilder.class), true, 5000, DiamondC.class);
+        DagNode terminal = new DagNode(DiamondTerminalBuilder.class,
+                Set.of(DiamondABuilder.class, DiamondBBuilder.class, DiamondCBuilder.class),
+                true, 5000, DiamondResult.class);
+
+        Dag dag = buildDag(List.of(nodeA, nodeB, nodeC, terminal), terminal);
+
+        DagExecutor executor = new DagExecutor(factory);
+        Object result = executor.execute(dag, new StubBuilderContext());
+
+        assertThat(result).isInstanceOf(DiamondResult.class);
+        DiamondResult diamond = (DiamondResult) result;
+        assertThat(diamond.a()).isEqualTo("alpha");
+        assertThat(diamond.b()).isEqualTo(99);
+        assertThat(diamond.c()).isEqualTo("alpha-99");
+    }
+
+    @Test
     void shouldReportAvailableDependenciesOnFailure() {
-        // A builder that tries to get a dependency that doesn't exist
         LoomBuilder<String> badBuilder = ctx -> {
-            ctx.getDependency(Dashboard.class); // not available
+            ctx.getDependency(Dashboard.class);
             return "unreachable";
         };
 
@@ -383,14 +496,11 @@ class DagExecutorTest {
         doReturn(new FastBuilder()).when(factory).createBuilderUntyped(FastBuilder.class);
         doReturn(badBuilder).when(factory).createBuilderUntyped(AssemblerBuilder.class);
 
-        Map<Class<? extends LoomBuilder<?>>, DagNode> nodes = new LinkedHashMap<>();
-        nodes.put(FastBuilder.class, new DagNode(FastBuilder.class, Set.of(), true, 5000, String.class));
-        nodes.put(AssemblerBuilder.class, new DagNode(AssemblerBuilder.class,
-                Set.of(FastBuilder.class), true, 5000, FinalResult.class));
+        DagNode fast = new DagNode(FastBuilder.class, Set.of(), true, 5000, String.class);
+        DagNode assembler = new DagNode(AssemblerBuilder.class,
+                Set.of(FastBuilder.class), true, 5000, FinalResult.class);
 
-        DagNode terminal = nodes.get(AssemblerBuilder.class);
-        List<DagNode> topoOrder = List.of(nodes.get(FastBuilder.class), terminal);
-        Dag dag = new Dag(nodes, topoOrder, terminal);
+        Dag dag = buildDag(List.of(fast, assembler), assembler);
 
         DagExecutor executor = new DagExecutor(factory);
 
@@ -425,14 +535,11 @@ class DagExecutorTest {
         doReturn(new NullReturningBuilder()).when(factory).createBuilderUntyped(NullReturningBuilder.class);
         doReturn(new NullConsumerBuilder()).when(factory).createBuilderUntyped(NullConsumerBuilder.class);
 
-        Map<Class<? extends LoomBuilder<?>>, DagNode> nodes = new LinkedHashMap<>();
-        nodes.put(NullReturningBuilder.class, new DagNode(NullReturningBuilder.class, Set.of(), true, 5000, String.class));
-        nodes.put(NullConsumerBuilder.class, new DagNode(NullConsumerBuilder.class,
-                Set.of(NullReturningBuilder.class), true, 5000, FinalResult.class));
+        DagNode nullReturning = new DagNode(NullReturningBuilder.class, Set.of(), true, 5000, String.class);
+        DagNode nullConsumer = new DagNode(NullConsumerBuilder.class,
+                Set.of(NullReturningBuilder.class), true, 5000, FinalResult.class);
 
-        DagNode terminal = nodes.get(NullConsumerBuilder.class);
-        List<DagNode> topoOrder = List.of(nodes.get(NullReturningBuilder.class), terminal);
-        Dag dag = new Dag(nodes, topoOrder, terminal);
+        Dag dag = buildDag(List.of(nullReturning, nullConsumer), nullConsumer);
 
         DagExecutor executor = new DagExecutor(factory);
         Object result = executor.execute(dag, new StubBuilderContext());
@@ -443,13 +550,10 @@ class DagExecutorTest {
 
     @Test
     void optionalFailedNodeStoresUnwrappedCause() {
-        // Optional node fails with LoomServiceClientException — verify the cause
-        // stored in BuilderResult is the original exception, not CompletionException
         BuilderFactory factory = mock(BuilderFactory.class);
         doReturn(new SlowBuilder()).when(factory).createBuilderUntyped(SlowBuilder.class);
         doReturn(new ServiceClientFailingBuilder()).when(factory).createBuilderUntyped(ServiceClientFailingBuilder.class);
 
-        // Collector that inspects both required and optional results
         LoomBuilder<String> inspectorBuilder = ctx -> {
             Integer required = ctx.getDependency(Integer.class);
             Optional<String> optional = ctx.getOptionalResultOf(ServiceClientFailingBuilder.class);
@@ -457,22 +561,16 @@ class DagExecutorTest {
         };
         doReturn(inspectorBuilder).when(factory).createBuilderUntyped(AssemblerBuilder.class);
 
-        Map<Class<? extends LoomBuilder<?>>, DagNode> nodes = new LinkedHashMap<>();
-        nodes.put(SlowBuilder.class, new DagNode(SlowBuilder.class, Set.of(), true, 5000, Integer.class));
-        nodes.put(ServiceClientFailingBuilder.class,
-                new DagNode(ServiceClientFailingBuilder.class, Set.of(), false, 5000, String.class));
-        nodes.put(AssemblerBuilder.class, new DagNode(AssemblerBuilder.class,
-                Set.of(SlowBuilder.class, ServiceClientFailingBuilder.class), true, 5000, FinalResult.class));
+        DagNode slow = new DagNode(SlowBuilder.class, Set.of(), true, 5000, Integer.class);
+        DagNode svcFailing = new DagNode(ServiceClientFailingBuilder.class, Set.of(), false, 5000, String.class);
+        DagNode assembler = new DagNode(AssemblerBuilder.class,
+                Set.of(SlowBuilder.class, ServiceClientFailingBuilder.class), true, 5000, FinalResult.class);
 
-        DagNode terminal = nodes.get(AssemblerBuilder.class);
-        List<DagNode> topoOrder = List.of(
-                nodes.get(SlowBuilder.class), nodes.get(ServiceClientFailingBuilder.class), terminal);
-        Dag dag = new Dag(nodes, topoOrder, terminal);
+        Dag dag = buildDag(List.of(slow, svcFailing, assembler), assembler);
 
         DagExecutor executor = new DagExecutor(factory);
         Object result = executor.execute(dag, new StubBuilderContext());
 
-        // The optional node failed, so its result is absent (not CompletionException)
         assertThat(result).isInstanceOf(String.class);
         assertThat((String) result).isEqualTo("required=42,optional=absent");
     }

--- a/loom-core/src/test/java/io/loom/core/exception/LoomServiceClientExceptionTest.java
+++ b/loom-core/src/test/java/io/loom/core/exception/LoomServiceClientExceptionTest.java
@@ -1,0 +1,49 @@
+package io.loom.core.exception;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoomServiceClientExceptionTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {400, 401, 403, 404, 405, 409, 422, 429, 499})
+    void clientErrors_notRetryable(int status) {
+        var ex = new LoomServiceClientException("svc", status, "error");
+        assertThat(ex.isRetryable()).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {500, 502, 503, 504, 599})
+    void serverErrors_retryable(int status) {
+        var ex = new LoomServiceClientException("svc", status, "error");
+        assertThat(ex.isRetryable()).isTrue();
+    }
+
+    @Test
+    void transportFailure_retryable() {
+        var ex = new LoomServiceClientException("svc", "Connection refused",
+                new java.io.IOException("Connection refused"));
+        assertThat(ex.getStatusCode()).isEqualTo(-1);
+        assertThat(ex.isRetryable()).isTrue();
+    }
+
+    @Test
+    void httpErrorConstructor_preservesFields() {
+        var cause = new RuntimeException("root");
+        var ex = new LoomServiceClientException("payment-svc", 502, "Bad Gateway", cause);
+        assertThat(ex.getServiceName()).isEqualTo("payment-svc");
+        assertThat(ex.getStatusCode()).isEqualTo(502);
+        assertThat(ex.getCause()).isSameAs(cause);
+        assertThat(ex.getMessage()).contains("payment-svc").contains("502");
+    }
+
+    @Test
+    void transportErrorConstructor_setsStatusMinusOne() {
+        var ex = new LoomServiceClientException("svc", "timeout", new RuntimeException());
+        assertThat(ex.getStatusCode()).isEqualTo(-1);
+        assertThat(ex.getMessage()).contains("svc").contains("timeout");
+    }
+}

--- a/loom-core/src/test/java/io/loom/core/service/ServiceResponseTest.java
+++ b/loom-core/src/test/java/io/loom/core/service/ServiceResponseTest.java
@@ -1,0 +1,107 @@
+package io.loom.core.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServiceResponseTest {
+
+    @Test
+    void isSuccessful_200() {
+        var resp = response(200);
+        assertThat(resp.isSuccessful()).isTrue();
+        assertThat(resp.isClientError()).isFalse();
+        assertThat(resp.isServerError()).isFalse();
+    }
+
+    @Test
+    void isSuccessful_299() {
+        assertThat(response(299).isSuccessful()).isTrue();
+    }
+
+    @Test
+    void isSuccessful_199_isFalse() {
+        assertThat(response(199).isSuccessful()).isFalse();
+    }
+
+    @Test
+    void isSuccessful_300_isFalse() {
+        assertThat(response(300).isSuccessful()).isFalse();
+    }
+
+    @Test
+    void isClientError_400() {
+        var resp = response(400);
+        assertThat(resp.isClientError()).isTrue();
+        assertThat(resp.isSuccessful()).isFalse();
+        assertThat(resp.isServerError()).isFalse();
+    }
+
+    @Test
+    void isClientError_499() {
+        assertThat(response(499).isClientError()).isTrue();
+    }
+
+    @Test
+    void isClientError_399_isFalse() {
+        assertThat(response(399).isClientError()).isFalse();
+    }
+
+    @Test
+    void isClientError_500_isFalse() {
+        assertThat(response(500).isClientError()).isFalse();
+    }
+
+    @Test
+    void isServerError_500() {
+        var resp = response(500);
+        assertThat(resp.isServerError()).isTrue();
+        assertThat(resp.isSuccessful()).isFalse();
+        assertThat(resp.isClientError()).isFalse();
+    }
+
+    @Test
+    void isServerError_599() {
+        assertThat(response(599).isServerError()).isTrue();
+    }
+
+    @Test
+    void isServerError_499_isFalse() {
+        assertThat(response(499).isServerError()).isFalse();
+    }
+
+    @Test
+    void nullDataAndHeaders() {
+        var resp = new ServiceResponse<String>(null, 404, null, null, null);
+        assertThat(resp.data()).isNull();
+        assertThat(resp.headers()).isNull();
+        assertThat(resp.rawBody()).isNull();
+        assertThat(resp.contentType()).isNull();
+        assertThat(resp.isClientError()).isTrue();
+    }
+
+    @Test
+    void emptyRawBody() {
+        var resp = new ServiceResponse<>("data", 200, Map.of(), new byte[0], "application/json");
+        assertThat(resp.data()).isEqualTo("data");
+        assertThat(resp.rawBody()).isEmpty();
+    }
+
+    @Test
+    void multiValueHeaders() {
+        Map<String, List<String>> headers = Map.of(
+                "Set-Cookie", List.of("a=1", "b=2"),
+                "X-Single", List.of("val")
+        );
+        var resp = new ServiceResponse<>(null, 200, headers, new byte[0], "text/plain");
+        assertThat(resp.headers().get("Set-Cookie")).containsExactly("a=1", "b=2");
+        assertThat(resp.headers().get("X-Single")).containsExactly("val");
+    }
+
+    private ServiceResponse<String> response(int statusCode) {
+        return new ServiceResponse<>("data", statusCode, Map.of(), "data".getBytes(), "application/json");
+    }
+}

--- a/loom-spring-boot-starter/src/main/java/io/loom/starter/codec/DslJsonHttpMessageConverter.java
+++ b/loom-spring-boot-starter/src/main/java/io/loom/starter/codec/DslJsonHttpMessageConverter.java
@@ -25,12 +25,20 @@ public class DslJsonHttpMessageConverter implements HttpMessageConverter<Object>
 
     @Override
     public boolean canRead(Class<?> clazz, MediaType mediaType) {
-        return mediaType == null || SUPPORTED.stream().anyMatch(s -> s.includes(mediaType));
+        if (mediaType == null) return true;
+        for (int i = 0; i < SUPPORTED.size(); i++) {
+            if (SUPPORTED.get(i).includes(mediaType)) return true;
+        }
+        return false;
     }
 
     @Override
     public boolean canWrite(Class<?> clazz, MediaType mediaType) {
-        return mediaType == null || SUPPORTED.stream().anyMatch(s -> s.includes(mediaType));
+        if (mediaType == null) return true;
+        for (int i = 0; i < SUPPORTED.size(); i++) {
+            if (SUPPORTED.get(i).includes(mediaType)) return true;
+        }
+        return false;
     }
 
     @Override

--- a/loom-spring-boot-starter/src/main/java/io/loom/starter/context/SpringBuilderContext.java
+++ b/loom-spring-boot-starter/src/main/java/io/loom/starter/context/SpringBuilderContext.java
@@ -10,7 +10,6 @@ import io.loom.starter.service.ServiceAccessorImpl;
 import io.loom.starter.service.ServiceClientRegistry;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class SpringBuilderContext implements BuilderContext {
 
@@ -28,7 +27,7 @@ public class SpringBuilderContext implements BuilderContext {
     private final Map<String, List<String>> unmodQueryParams;
     private final Map<String, List<String>> unmodHeaders;
 
-    private final ConcurrentHashMap<String, Object> attributes = new ConcurrentHashMap<>();
+    private final Map<String, Object> attributes = new HashMap<>();
     private static final Object NULL_SENTINEL = new Object();
 
     // Array-based result storage (initialized by DagExecutor before DAG execution)

--- a/loom-spring-boot-starter/src/main/java/io/loom/starter/service/RestServiceClient.java
+++ b/loom-spring-boot-starter/src/main/java/io/loom/starter/service/RestServiceClient.java
@@ -5,18 +5,25 @@ import io.loom.core.engine.RetryExecutor;
 import io.loom.core.exception.LoomServiceClientException;
 import io.loom.core.service.RetryConfig;
 import io.loom.core.service.ServiceClient;
+import io.loom.core.service.ServiceResponse;
 import io.loom.starter.codec.DslJsonHttpMessageConverter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
+import java.io.IOException;
 import java.net.http.HttpClient;
-import java.util.concurrent.Executors;
 import java.time.Duration;
+
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
 
 @Slf4j
 public class RestServiceClient implements ServiceClient {
@@ -25,6 +32,7 @@ public class RestServiceClient implements ServiceClient {
     private final RestClient restClient;
     private final RetryExecutor retryExecutor;
     private final RetryConfig retryConfig;
+    private final JsonCodec jsonCodec;
 
     public RestServiceClient(String name, String url, long connectTimeoutMs,
                               long readTimeoutMs, RetryConfig retryConfig,
@@ -32,6 +40,7 @@ public class RestServiceClient implements ServiceClient {
         this.name = name;
         this.retryExecutor = retryExecutor;
         this.retryConfig = retryConfig;
+        this.jsonCodec = jsonCodec;
 
         var httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofMillis(connectTimeoutMs))
@@ -160,5 +169,113 @@ public class RestServiceClient implements ServiceClient {
                 throw new LoomServiceClientException(name, e.getMessage(), e);
             }
         }, retryConfig, name + " PATCH " + path);
+    }
+
+    @Override
+    public ServiceResponse<byte[]> proxy(String method, String path, byte[] body, Map<String, String> headers) {
+        return retryExecutor.execute(() -> {
+            try {
+                var spec = restClient.method(HttpMethod.valueOf(method.toUpperCase())).uri(path);
+                if (headers != null) {
+                    headers.forEach(spec::header);
+                }
+                if (body != null && body.length > 0) {
+                    spec.body(body);
+                }
+                ResponseEntity<byte[]> entity = spec.retrieve().toEntity(byte[].class);
+                return buildByteResponse(entity);
+            } catch (RestClientResponseException e) {
+                return new ServiceResponse<>(
+                        null,
+                        e.getStatusCode().value(),
+                        toMultiValueMap(e.getResponseHeaders()),
+                        e.getResponseBodyAsByteArray(),
+                        extractContentType(e.getResponseHeaders())
+                );
+            } catch (Exception e) {
+                throw new LoomServiceClientException(name, e.getMessage(), e);
+            }
+        }, retryConfig, name + " " + method.toUpperCase() + " " + path);
+    }
+
+    @Override
+    public <T> ServiceResponse<T> exchange(String method, String path, Object body,
+                                            Class<T> responseType, Map<String, String> headers) {
+        return retryExecutor.execute(() -> {
+            try {
+                var spec = restClient.method(HttpMethod.valueOf(method.toUpperCase())).uri(path);
+                if (headers != null) {
+                    headers.forEach(spec::header);
+                }
+                if (body != null) {
+                    spec.body(body);
+                }
+                ResponseEntity<byte[]> entity = spec.retrieve().toEntity(byte[].class);
+                byte[] rawBody = entity.getBody() != null ? entity.getBody() : new byte[0];
+                T data = deserializeIfPresent(rawBody, responseType);
+                return new ServiceResponse<>(
+                        data,
+                        entity.getStatusCode().value(),
+                        toMultiValueMap(entity.getHeaders()),
+                        rawBody,
+                        extractContentType(entity.getHeaders())
+                );
+            } catch (RestClientResponseException e) {
+                return new ServiceResponse<>(
+                        null,
+                        e.getStatusCode().value(),
+                        toMultiValueMap(e.getResponseHeaders()),
+                        e.getResponseBodyAsByteArray(),
+                        extractContentType(e.getResponseHeaders())
+                );
+            } catch (Exception e) {
+                throw new LoomServiceClientException(name, e.getMessage(), e);
+            }
+        }, retryConfig, name + " " + method.toUpperCase() + " " + path);
+    }
+
+    private ServiceResponse<byte[]> buildByteResponse(ResponseEntity<byte[]> entity) {
+        byte[] rawBody = entity.getBody() != null ? entity.getBody() : new byte[0];
+        return new ServiceResponse<>(
+                rawBody,
+                entity.getStatusCode().value(),
+                toMultiValueMap(entity.getHeaders()),
+                rawBody,
+                extractContentType(entity.getHeaders())
+        );
+    }
+
+    private <T> T deserializeIfPresent(byte[] rawBody, Class<T> responseType) {
+        if (rawBody == null || rawBody.length == 0) {
+            return null;
+        }
+        if (responseType == byte[].class) {
+            @SuppressWarnings("unchecked")
+            T result = (T) rawBody;
+            return result;
+        }
+        try {
+            return jsonCodec.readValue(rawBody, responseType);
+        } catch (IOException e) {
+            log.warn("[Loom] Failed to deserialize response body for service '{}' as {}: {}",
+                    name, responseType.getSimpleName(), e.getMessage());
+            return null;
+        }
+    }
+
+    private static Map<String, List<String>> toMultiValueMap(org.springframework.http.HttpHeaders httpHeaders) {
+        if (httpHeaders == null) {
+            return Map.of();
+        }
+        Map<String, List<String>> result = new LinkedHashMap<>();
+        httpHeaders.forEach((key, values) -> result.put(key, List.copyOf(values)));
+        return Map.copyOf(result);
+    }
+
+    private static String extractContentType(org.springframework.http.HttpHeaders httpHeaders) {
+        if (httpHeaders == null || httpHeaders.getContentType() == null) {
+            return "application/octet-stream";
+        }
+        return httpHeaders.getContentType().toString();
     }
 }

--- a/loom-spring-boot-starter/src/main/java/io/loom/starter/service/RouteInvokerImpl.java
+++ b/loom-spring-boot-starter/src/main/java/io/loom/starter/service/RouteInvokerImpl.java
@@ -3,6 +3,7 @@ package io.loom.starter.service;
 import io.loom.core.service.RouteConfig;
 import io.loom.core.service.RouteInvoker;
 import io.loom.core.service.ServiceClient;
+import io.loom.core.service.ServiceResponse;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -97,6 +98,31 @@ public class RouteInvokerImpl implements RouteInvoker {
     @Override
     public <T> T patch(Class<T> responseType) {
         return client.patch(resolvedPath(), requestBody, responseType, headersOrEmpty());
+    }
+
+    @Override
+    public <T> ServiceResponse<T> getResponse(Class<T> responseType) {
+        return client.exchange("GET", resolvedPath(), null, responseType, headersOrEmpty());
+    }
+
+    @Override
+    public <T> ServiceResponse<T> postResponse(Class<T> responseType) {
+        return client.exchange("POST", resolvedPath(), requestBody, responseType, headersOrEmpty());
+    }
+
+    @Override
+    public <T> ServiceResponse<T> putResponse(Class<T> responseType) {
+        return client.exchange("PUT", resolvedPath(), requestBody, responseType, headersOrEmpty());
+    }
+
+    @Override
+    public <T> ServiceResponse<T> deleteResponse(Class<T> responseType) {
+        return client.exchange("DELETE", resolvedPath(), null, responseType, headersOrEmpty());
+    }
+
+    @Override
+    public <T> ServiceResponse<T> patchResponse(Class<T> responseType) {
+        return client.exchange("PATCH", resolvedPath(), requestBody, responseType, headersOrEmpty());
     }
 
     String resolvedPath() {

--- a/loom-spring-boot-starter/src/main/java/io/loom/starter/web/LoomHandlerAdapter.java
+++ b/loom-spring-boot-starter/src/main/java/io/loom/starter/web/LoomHandlerAdapter.java
@@ -200,7 +200,9 @@ public class LoomHandlerAdapter implements HandlerAdapter {
             });
         }
 
-        response.setContentType(upstream.contentType());
+        if (upstream.contentType() != null) {
+            response.setContentType(upstream.contentType());
+        }
 
         if (upstream.rawBody() != null && upstream.rawBody().length > 0) {
             response.getOutputStream().write(upstream.rawBody());

--- a/loom-spring-boot-starter/src/main/java/io/loom/starter/web/LoomHandlerMapping.java
+++ b/loom-spring-boot-starter/src/main/java/io/loom/starter/web/LoomHandlerMapping.java
@@ -20,7 +20,7 @@ public class LoomHandlerMapping extends AbstractHandlerMapping {
 
     public LoomHandlerMapping(ApiRegistry apiRegistry) {
         this.apiRegistry = apiRegistry;
-        setOrder(Ordered.HIGHEST_PRECEDENCE + 100);
+        setOrder(Ordered.HIGHEST_PRECEDENCE);
     }
 
     @Override

--- a/loom-spring-boot-starter/src/main/java/io/loom/starter/web/LoomHttpContextImpl.java
+++ b/loom-spring-boot-starter/src/main/java/io/loom/starter/web/LoomHttpContextImpl.java
@@ -9,7 +9,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class LoomHttpContextImpl implements LoomHttpContext {
 
@@ -22,7 +21,7 @@ public class LoomHttpContextImpl implements LoomHttpContext {
 
     private Map<String, List<String>> cachedHeaders;
 
-    private final ConcurrentHashMap<String, Object> attributes = new ConcurrentHashMap<>();
+    private final Map<String, Object> attributes = new HashMap<>();
     private Object responseBody;
     private int responseStatus = 200;
     private Map<String, String> queryParamDefaults;

--- a/loom-spring-boot-starter/src/test/java/io/loom/starter/context/SpringBuilderContextTest.java
+++ b/loom-spring-boot-starter/src/test/java/io/loom/starter/context/SpringBuilderContextTest.java
@@ -1,0 +1,157 @@
+package io.loom.starter.context;
+
+import io.loom.core.builder.LoomBuilder;
+import io.loom.core.builder.BuilderContext;
+import io.loom.core.codec.JsonCodec;
+import io.loom.core.exception.LoomDependencyResolutionException;
+import io.loom.starter.service.ServiceClientRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SpringBuilderContextTest {
+
+    // ── Stub builders and types ──
+
+    record Alpha(String value) {}
+    record Beta(int value) {}
+    record Gamma(String combined) {}
+
+    static class AlphaBuilder implements LoomBuilder<Alpha> {
+        public Alpha build(BuilderContext ctx) { return new Alpha("a"); }
+    }
+    static class BetaBuilder implements LoomBuilder<Beta> {
+        public Beta build(BuilderContext ctx) { return new Beta(42); }
+    }
+    static class GammaBuilder implements LoomBuilder<Gamma> {
+        public Gamma build(BuilderContext ctx) { return new Gamma("g"); }
+    }
+
+    // ── Helper ──
+
+    @SuppressWarnings("unchecked")
+    private SpringBuilderContext createContext() {
+        JsonCodec codec = mock(JsonCodec.class);
+        ServiceClientRegistry registry = mock(ServiceClientRegistry.class);
+        return new SpringBuilderContext(
+                "GET", "/test",
+                Map.of(), Map.of(), Map.of(),
+                null, codec, registry, null);
+    }
+
+    private void initThreeNodeStorage(SpringBuilderContext ctx) {
+        Map<Class<?>, Integer> typeIndexMap = new HashMap<>();
+        typeIndexMap.put(Alpha.class, 0);
+        typeIndexMap.put(Beta.class, 1);
+        typeIndexMap.put(Gamma.class, 2);
+
+        Map<Class<? extends LoomBuilder<?>>, Integer> builderIndexMap = new HashMap<>();
+        builderIndexMap.put(AlphaBuilder.class, 0);
+        builderIndexMap.put(BetaBuilder.class, 1);
+        builderIndexMap.put(GammaBuilder.class, 2);
+
+        ctx.initResultStorage(3, typeIndexMap, builderIndexMap);
+    }
+
+    // ── Tests ──
+
+    @Test
+    void initResultStorage_createsCorrectSizedArray() {
+        SpringBuilderContext ctx = createContext();
+        initThreeNodeStorage(ctx);
+
+        // Unpopulated slots should return Optional.empty()
+        assertThat(ctx.getOptionalDependency(Alpha.class)).isEmpty();
+        assertThat(ctx.getOptionalDependency(Beta.class)).isEmpty();
+        assertThat(ctx.getOptionalDependency(Gamma.class)).isEmpty();
+    }
+
+    @Test
+    void storeAndGetDependency_roundTrips() {
+        SpringBuilderContext ctx = createContext();
+        initThreeNodeStorage(ctx);
+
+        Alpha alpha = new Alpha("hello");
+        ctx.storeResult(AlphaBuilder.class, Alpha.class, alpha);
+
+        Alpha retrieved = ctx.getDependency(Alpha.class);
+        assertThat(retrieved).isSameAs(alpha);
+        assertThat(retrieved.value()).isEqualTo("hello");
+    }
+
+    @Test
+    void storeAndGetResultOf_roundTrips() {
+        SpringBuilderContext ctx = createContext();
+        initThreeNodeStorage(ctx);
+
+        Beta beta = new Beta(99);
+        ctx.storeResult(BetaBuilder.class, Beta.class, beta);
+
+        Beta retrieved = ctx.getResultOf(BetaBuilder.class);
+        assertThat(retrieved).isSameAs(beta);
+        assertThat(retrieved.value()).isEqualTo(99);
+    }
+
+    @Test
+    void storeNull_returnsNullViaSentinel() {
+        SpringBuilderContext ctx = createContext();
+        initThreeNodeStorage(ctx);
+
+        ctx.storeResult(AlphaBuilder.class, Alpha.class, null);
+
+        // getDependency should return null (unwrapped from sentinel)
+        Alpha result = ctx.getDependency(Alpha.class);
+        assertThat(result).isNull();
+
+        // getOptionalDependency should return Optional with null inside → Optional.empty() via ofNullable
+        Optional<Alpha> optional = ctx.getOptionalDependency(Alpha.class);
+        assertThat(optional).isEmpty();
+    }
+
+    @Test
+    void getOptionalDependency_unregisteredType_returnsEmpty() {
+        SpringBuilderContext ctx = createContext();
+        initThreeNodeStorage(ctx);
+
+        // String is not in the DAG's typeIndexMap
+        Optional<String> result = ctx.getOptionalDependency(String.class);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getOptionalResultOf_unregisteredBuilder_returnsEmpty() {
+        SpringBuilderContext ctx = createContext();
+        initThreeNodeStorage(ctx);
+
+        // Use a builder class that's not registered
+        @SuppressWarnings("unchecked")
+        Class<? extends LoomBuilder<String>> unknownBuilder =
+                (Class<? extends LoomBuilder<String>>) (Class<?>) LoomBuilder.class;
+
+        Optional<String> result = ctx.getOptionalResultOf(unknownBuilder);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getDependency_beforeStorage_throwsWithDiagnostics() {
+        SpringBuilderContext ctx = createContext();
+        initThreeNodeStorage(ctx);
+
+        // Store Alpha so it appears in availableTypes, but don't store Beta
+        ctx.storeResult(AlphaBuilder.class, Alpha.class, new Alpha("stored"));
+
+        assertThatThrownBy(() -> ctx.getDependency(Beta.class))
+                .isInstanceOf(LoomDependencyResolutionException.class)
+                .satisfies(thrown -> {
+                    LoomDependencyResolutionException ex = (LoomDependencyResolutionException) thrown;
+                    assertThat(ex.getRequestedType()).isEqualTo("Beta");
+                    assertThat(ex.getAvailableTypes()).contains("Alpha");
+                    assertThat(ex.getCompletedBuilders()).contains("AlphaBuilder");
+                });
+    }
+}

--- a/loom-spring-boot-starter/src/test/java/io/loom/starter/web/LoomHandlerAdapterTest.java
+++ b/loom-spring-boot-starter/src/test/java/io/loom/starter/web/LoomHandlerAdapterTest.java
@@ -11,6 +11,7 @@ import io.loom.core.interceptor.LoomInterceptor;
 import io.loom.core.model.ApiDefinition;
 import io.loom.core.model.ProxyPathTemplate;
 import io.loom.core.service.ServiceClient;
+import io.loom.core.service.ServiceResponse;
 import io.loom.starter.registry.InterceptorRegistry;
 import io.loom.starter.service.ServiceClientRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -116,7 +117,7 @@ class LoomHandlerAdapterTest {
         ServiceClient client = mock(ServiceClient.class);
         when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
         LoomServiceClientException original = new LoomServiceClientException("test-svc", 502, "Bad Gateway");
-        when(client.get(any(), eq(Object.class), any())).thenThrow(original);
+        when(client.proxy(any(), any(), any(), any())).thenThrow(original);
 
         MockHttpServletRequest request = createRequest("GET", "/api/proxy");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -134,7 +135,7 @@ class LoomHandlerAdapterTest {
     void passthroughPath_nonLoomExceptionWrappedWithApiRoute() {
         ServiceClient client = mock(ServiceClient.class);
         when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
-        when(client.get(any(), eq(Object.class), any())).thenThrow(new RuntimeException("connection reset"));
+        when(client.proxy(any(), any(), any(), any())).thenThrow(new RuntimeException("connection reset"));
 
         MockHttpServletRequest request = createRequest("GET", "/api/proxy");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -156,7 +157,9 @@ class LoomHandlerAdapterTest {
     void passthroughPath_singleValueHeaderNotJoined() throws Exception {
         ServiceClient client = mock(ServiceClient.class);
         when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
-        when(client.get(any(), eq(Object.class), any())).thenReturn(Map.of("status", "ok"));
+        ServiceResponse<byte[]> upstream = new ServiceResponse<>(
+                "{\"status\":\"ok\"}".getBytes(), 200, Map.of(), "{\"status\":\"ok\"}".getBytes(), "application/json");
+        when(client.proxy(any(), any(), any(), any())).thenReturn(upstream);
 
         MockHttpServletRequest request = createRequest("GET", "/api/proxy");
         request.addHeader("X-Custom", "single-value");
@@ -167,7 +170,7 @@ class LoomHandlerAdapterTest {
 
         @SuppressWarnings("unchecked")
         var headersCaptor = org.mockito.ArgumentCaptor.forClass(Map.class);
-        verify(client).get(any(), eq(Object.class), headersCaptor.capture());
+        verify(client).proxy(any(), any(), any(), headersCaptor.capture());
 
         @SuppressWarnings("unchecked")
         Map<String, String> forwardedHeaders = headersCaptor.getValue();
@@ -178,7 +181,9 @@ class LoomHandlerAdapterTest {
     void passthroughPath_hopByHopHeadersFiltered() throws Exception {
         ServiceClient client = mock(ServiceClient.class);
         when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
-        when(client.get(any(), eq(Object.class), any())).thenReturn(Map.of("status", "ok"));
+        ServiceResponse<byte[]> upstream = new ServiceResponse<>(
+                "{\"status\":\"ok\"}".getBytes(), 200, Map.of(), "{\"status\":\"ok\"}".getBytes(), "application/json");
+        when(client.proxy(any(), any(), any(), any())).thenReturn(upstream);
 
         MockHttpServletRequest request = createRequest("GET", "/api/proxy");
         request.addHeader("Host", "localhost:8080");
@@ -192,7 +197,7 @@ class LoomHandlerAdapterTest {
 
         @SuppressWarnings("unchecked")
         var headersCaptor = org.mockito.ArgumentCaptor.forClass(Map.class);
-        verify(client).get(any(), eq(Object.class), headersCaptor.capture());
+        verify(client).proxy(any(), any(), any(), headersCaptor.capture());
 
         @SuppressWarnings("unchecked")
         Map<String, String> forwardedHeaders = headersCaptor.getValue();
@@ -247,5 +252,204 @@ class LoomHandlerAdapterTest {
         assertThatThrownBy(() -> smallAdapter.handle(request, response, handler))
                 .isInstanceOf(LoomException.class)
                 .hasMessageContaining("Request body too large");
+    }
+
+    // ── New passthrough response forwarding tests ──
+
+    @Test
+    void passthroughPath_forwardsUpstreamStatusCode() throws Exception {
+        ServiceClient client = mock(ServiceClient.class);
+        when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
+        ServiceResponse<byte[]> upstream = new ServiceResponse<>(
+                "Not Found".getBytes(), 404, Map.of(), "Not Found".getBytes(), "application/json");
+        when(client.proxy(any(), any(), any(), any())).thenReturn(upstream);
+
+        MockHttpServletRequest request = createRequest("GET", "/api/proxy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoomRequestHandler handler = passthroughHandler("GET", "/api/proxy", "test-svc", "get-all");
+
+        adapter.handle(request, response, handler);
+
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void passthroughPath_forwardsUpstreamResponseHeaders() throws Exception {
+        ServiceClient client = mock(ServiceClient.class);
+        when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
+        Map<String, List<String>> upstreamHeaders = Map.of(
+                "Cache-Control", List.of("max-age=3600"),
+                "X-Request-Id", List.of("abc-123")
+        );
+        ServiceResponse<byte[]> upstream = new ServiceResponse<>(
+                "{}".getBytes(), 200, upstreamHeaders, "{}".getBytes(), "application/json");
+        when(client.proxy(any(), any(), any(), any())).thenReturn(upstream);
+
+        MockHttpServletRequest request = createRequest("GET", "/api/proxy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoomRequestHandler handler = passthroughHandler("GET", "/api/proxy", "test-svc", "get-all");
+
+        adapter.handle(request, response, handler);
+
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("max-age=3600");
+        assertThat(response.getHeader("X-Request-Id")).isEqualTo("abc-123");
+    }
+
+    @Test
+    void passthroughPath_filtersHopByHopResponseHeaders() throws Exception {
+        ServiceClient client = mock(ServiceClient.class);
+        when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
+        Map<String, List<String>> upstreamHeaders = Map.of(
+                "Transfer-Encoding", List.of("chunked"),
+                "Connection", List.of("keep-alive"),
+                "X-Custom", List.of("value")
+        );
+        ServiceResponse<byte[]> upstream = new ServiceResponse<>(
+                "{}".getBytes(), 200, upstreamHeaders, "{}".getBytes(), "application/json");
+        when(client.proxy(any(), any(), any(), any())).thenReturn(upstream);
+
+        MockHttpServletRequest request = createRequest("GET", "/api/proxy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoomRequestHandler handler = passthroughHandler("GET", "/api/proxy", "test-svc", "get-all");
+
+        adapter.handle(request, response, handler);
+
+        assertThat(response.getHeader("Transfer-Encoding")).isNull();
+        assertThat(response.getHeader("Connection")).isNull();
+        assertThat(response.getHeader("X-Custom")).isEqualTo("value");
+    }
+
+    @Test
+    void passthroughPath_preservesNonJsonContentType() throws Exception {
+        ServiceClient client = mock(ServiceClient.class);
+        when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
+        byte[] xmlBody = "<root><status>ok</status></root>".getBytes();
+        ServiceResponse<byte[]> upstream = new ServiceResponse<>(
+                xmlBody, 200, Map.of(), xmlBody, "application/xml");
+        when(client.proxy(any(), any(), any(), any())).thenReturn(upstream);
+
+        MockHttpServletRequest request = createRequest("GET", "/api/proxy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoomRequestHandler handler = passthroughHandler("GET", "/api/proxy", "test-svc", "get-all");
+
+        adapter.handle(request, response, handler);
+
+        assertThat(response.getContentType()).isEqualTo("application/xml");
+        assertThat(response.getContentAsString()).isEqualTo("<root><status>ok</status></root>");
+    }
+
+    @Test
+    void passthroughPath_contentTypeNotDuplicatedInResponseHeaders() throws Exception {
+        ServiceClient client = mock(ServiceClient.class);
+        when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
+        // Upstream includes Content-Type in both the headers map and contentType field
+        Map<String, List<String>> upstreamHeaders = Map.of(
+                "Content-Type", List.of("application/xml"),
+                "X-Custom", List.of("value")
+        );
+        ServiceResponse<byte[]> upstream = new ServiceResponse<>(
+                "<ok/>".getBytes(), 200, upstreamHeaders, "<ok/>".getBytes(), "application/xml");
+        when(client.proxy(any(), any(), any(), any())).thenReturn(upstream);
+
+        MockHttpServletRequest request = createRequest("GET", "/api/proxy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoomRequestHandler handler = passthroughHandler("GET", "/api/proxy", "test-svc", "get-all");
+
+        adapter.handle(request, response, handler);
+
+        // Content-Type should appear exactly once (set via setContentType, not addHeader)
+        assertThat(response.getContentType()).isEqualTo("application/xml");
+        assertThat(response.getHeaders("Content-Type")).hasSize(1);
+        // Other headers still forwarded
+        assertThat(response.getHeader("X-Custom")).isEqualTo("value");
+    }
+
+    @Test
+    void passthroughPath_contentTypeFilteringIsCaseInsensitive() throws Exception {
+        ServiceClient client = mock(ServiceClient.class);
+        when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
+        // Mixed-case content-type key in upstream headers
+        Map<String, List<String>> upstreamHeaders = new java.util.LinkedHashMap<>();
+        upstreamHeaders.put("content-type", List.of("text/html"));
+        upstreamHeaders.put("X-Other", List.of("val"));
+        ServiceResponse<byte[]> upstream = new ServiceResponse<>(
+                "hi".getBytes(), 200, upstreamHeaders, "hi".getBytes(), "text/html");
+        when(client.proxy(any(), any(), any(), any())).thenReturn(upstream);
+
+        MockHttpServletRequest request = createRequest("GET", "/api/proxy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoomRequestHandler handler = passthroughHandler("GET", "/api/proxy", "test-svc", "get-all");
+
+        adapter.handle(request, response, handler);
+
+        assertThat(response.getHeaders("Content-Type")).hasSize(1);
+        assertThat(response.getContentType()).isEqualTo("text/html");
+    }
+
+    @Test
+    void passthroughPath_multiValueResponseHeadersPreserved() throws Exception {
+        ServiceClient client = mock(ServiceClient.class);
+        when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
+        Map<String, List<String>> upstreamHeaders = Map.of(
+                "X-Multi", List.of("val1", "val2", "val3")
+        );
+        ServiceResponse<byte[]> upstream = new ServiceResponse<>(
+                "{}".getBytes(), 200, upstreamHeaders, "{}".getBytes(), "application/json");
+        when(client.proxy(any(), any(), any(), any())).thenReturn(upstream);
+
+        MockHttpServletRequest request = createRequest("GET", "/api/proxy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoomRequestHandler handler = passthroughHandler("GET", "/api/proxy", "test-svc", "get-all");
+
+        adapter.handle(request, response, handler);
+
+        assertThat(response.getHeaders("X-Multi")).containsExactly("val1", "val2", "val3");
+    }
+
+    @Test
+    void passthroughPath_writesRawBytesWithoutJsonCodec() throws Exception {
+        ServiceClient client = mock(ServiceClient.class);
+        when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
+        byte[] rawBytes = "{\"raw\":true}".getBytes();
+        ServiceResponse<byte[]> upstream = new ServiceResponse<>(
+                rawBytes, 200, Map.of(), rawBytes, "application/json");
+        when(client.proxy(any(), any(), any(), any())).thenReturn(upstream);
+
+        MockHttpServletRequest request = createRequest("GET", "/api/proxy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoomRequestHandler handler = passthroughHandler("GET", "/api/proxy", "test-svc", "get-all");
+
+        adapter.handle(request, response, handler);
+
+        // jsonCodec.writeValue() should never be called for passthrough
+        verify(jsonCodec, never()).writeValue(any(), any());
+        assertThat(response.getContentAsString()).isEqualTo("{\"raw\":true}");
+    }
+
+    @Test
+    void passthroughPath_interceptorShortCircuitStillUsesJsonPath() throws Exception {
+        LoomInterceptor shortCircuitInterceptor = new LoomInterceptor() {
+            @Override
+            public void handle(LoomHttpContext ctx, InterceptorChain chain) {
+                ctx.setResponseBody(Map.of("error", "blocked"));
+                ctx.setResponseStatus(403);
+            }
+        };
+        when(interceptorRegistry.getInterceptors(any())).thenReturn(List.of(shortCircuitInterceptor));
+
+        ServiceClient client = mock(ServiceClient.class);
+        when(serviceClientRegistry.getRouteClient("test-svc", "get-all")).thenReturn(client);
+
+        MockHttpServletRequest request = createRequest("GET", "/api/proxy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        LoomRequestHandler handler = passthroughHandler("GET", "/api/proxy", "test-svc", "get-all");
+
+        adapter.handle(request, response, handler);
+
+        // proxy() never called because interceptor short-circuited
+        verify(client, never()).proxy(any(), any(), any(), any());
+        // Falls back to JSON response path
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentType()).isEqualTo("application/json");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <module>loom-spring-boot-starter</module>
         <module>loom-ui</module>
         <module>loom-example</module>
+        <module>loom-benchmark</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary

- **Performance**: Replace per-request ConcurrentHashMaps with pre-indexed `Object[]` arrays, pre-compute DAG node indices at compile time, add radix trie route matching, lazy header/query param materialization, eliminate stream/iterator allocations in hot paths, and optimize header filtering — eliminating GC pressure on hot paths
- **ServiceResponse API**: Add non-throwing `proxy()`/`exchange()` methods and `*Response()` fluent API for graceful error handling in builders and raw byte passthrough in proxy mode
- **Bug fixes**: Stop retrying 4xx client errors, fix duplicate Content-Type in proxy responses, add retry wrapping to `proxy()`/`exchange()`
- **Benchmarks**: Add `loom-benchmark` module with JMH benchmarks for DAG execution, route matching, context creation, JSON codec, and end-to-end pipeline

## Fixes

- Fixes #2 — Replace all per-request CHMs with pre-indexed arrays (including attributes maps in LoomHttpContextImpl and SpringBuilderContext)
- Fixes #3 — Lazy header/query param materialization
- Fixes #4 — In-place path matching in RouteTrie
- Fixes #6 — Eliminate per-request Collections.unmodifiableMap() wrappers
- Partially addresses #7 — Reduce Spring/DispatcherServlet overhead (RouteTrie caching, HIGHEST_PRECEDENCE ordering, pre-compiled ProxyPathTemplate, ServiceClient caching done; servlet Filter bypass deferred)
- Fixes #8 — Optimize CompletableFuture allocation in DagExecutor
- Fixes #15 — 4xx client errors incorrectly retried with exponential backoff
- Fixes #16 — Duplicate Content-Type header in proxy response forwarding
- Fixes #17 — proxy() and exchange() missing retry wrapping

## Test plan

- [x] All tests pass (`mvn clean test`)
- [x] Run JMH benchmarks to validate perf gains (`java -jar loom-benchmark/target/benchmarks.jar -f 1 -wi 3 -i 5 -prof gc`)
- [ ] Manual smoke test with loom-example app

🤖 Generated with [Claude Code](https://claude.com/claude-code)