### PR TITLE
Fix global vs per-API interceptor classification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ java -jar loom-benchmark/target/benchmarks.jar -f 1 -wi 3 -i 5 -prof gc
 
 Five Maven modules with a strict dependency hierarchy:
 
-- **loom-core** — Pure Java, zero Spring dependencies. Contains annotations (`@LoomApi`, `@LoomGraph`, `@Node`, `@LoomProxy`), core interfaces (`LoomBuilder<O>`, `BuilderContext`, `LoomInterceptor`, `ServiceClient`, `ServiceAccessor`, `RouteInvoker`), the DAG engine (`DagCompiler`, `DagValidator`, `DagExecutor`), config records (`ServiceConfig`, `RouteConfig`, `RetryConfig`), and the `JsonCodec`/`DslJsonCodec` JSON abstraction.
+- **loom-core** — Pure Java, zero Spring dependencies. Contains annotations (`@LoomApi`, `@LoomGraph`, `@Node`, `@LoomProxy`), core interfaces (`LoomBuilder<O>`, `BuilderContext`, `LoomInterceptor`, `LoomGlobalInterceptor`, `ServiceClient`, `ServiceAccessor`, `RouteInvoker`), the DAG engine (`DagCompiler`, `DagValidator`, `DagExecutor`), config records (`ServiceConfig`, `RouteConfig`, `RetryConfig`), and the `JsonCodec`/`DslJsonCodec` JSON abstraction.
 
 - **loom-spring-boot-starter** — Spring Boot auto-configuration layer. Wires core engine into Spring's HTTP dispatch via custom `LoomHandlerMapping` → `LoomHandlerAdapter` → `LoomRequestHandler`. Handles classpath scanning (`LoomAnnotationScanner`), service client management (`RestServiceClient`), and interceptor chains.
 
@@ -65,6 +65,8 @@ Five Maven modules with a strict dependency hierarchy:
 **`ServiceResponse<T>`** (`io.loom.core.service`) — Unified response wrapper record carrying `data` (typed), `statusCode`, `headers`, `rawBody`, and `contentType`. Convenience methods: `isSuccessful()`, `isClientError()`, `isServerError()`. Used in two modes:
 - **Builder mode:** `RouteInvoker.*Response()` methods (e.g. `getResponse()`, `postResponse()`) call `ServiceClient.exchange()` which returns `ServiceResponse<T>` without throwing on 4xx/5xx, letting builders inspect status and handle errors gracefully.
 - **Passthrough mode:** `LoomHandlerAdapter` calls `ServiceClient.proxy()` which returns `ServiceResponse<byte[]>` for raw byte forwarding with proper status/header/content-type propagation.
+
+**Global vs per-API interceptors:** Interceptors implementing `LoomGlobalInterceptor` run on every request. Interceptors implementing only `LoomInterceptor` are per-API and only execute when explicitly referenced via `@LoomApi(interceptors = {...})`. Both types are available in the `InterceptorRegistry`; global ones are auto-included, per-API ones are merged in and deduplicated when requested.
 
 **Interceptor → builder communication:** Interceptors set attributes via `ctx.setAttribute()`, builders read them via `ctx.getAttribute()`.
 
@@ -113,6 +115,7 @@ Tests exist in `loom-core` and `loom-spring-boot-starter`:
 - `loom-core/src/test/.../service/ServiceConfigTest.java` — effective timeout/retry resolution
 - `loom-spring-boot-starter/src/test/.../web/PathMatcherTest.java` — URL path matching
 - `loom-spring-boot-starter/src/test/.../web/LoomHandlerAdapterTest.java` — handler dispatch, passthrough response forwarding, interceptor short-circuit
+- `loom-spring-boot-starter/src/test/.../registry/InterceptorRegistryTest.java` — global vs per-API interceptor filtering, deduplication, ordering, isGlobal()
 - `loom-spring-boot-starter/src/test/.../service/RouteInvokerImplTest.java` — fluent route invoker with auto-forwarding and `*Response()` exchange methods
 - `loom-spring-boot-starter/src/test/.../service/ServiceClientRegistryTest.java` — route client registration/lookup
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Loom executes it with maximum parallelism using virtual threads.
   codes and error bodies without catching exceptions
 - **Transparent proxy forwarding** — Passthrough APIs forward upstream status codes, response
   headers, and content types as-is (not hardcoded to JSON)
-- **Interceptor chains** — Request/response interceptors with attribute passing to builders
+- **Interceptor chains** — Global interceptors (`LoomGlobalInterceptor`) run on every request; per-API interceptors (`LoomInterceptor`) run only when referenced in `@LoomApi(interceptors = {...})`. Both support attribute passing to builders
 - **Embedded DAG visualization** — Dark-themed UI at `/loom/ui` powered by D3.js + dagre-d3
 - **High-performance JSON** — dsl-json for fast, reflection-free serialization on both response
   writing and service calls
@@ -325,7 +325,8 @@ dependencies resolve.
 |-------------------|-------------------------------------------------------------------------------------------------------|
 | `LoomBuilder<O>`  | DAG node implementation. `O build(BuilderContext ctx)`                                                |
 | `BuilderContext`  | Shared context for all builders in a request                                                          |
-| `LoomInterceptor` | Request/response processing. `void handle(LoomHttpContext, InterceptorChain)` + `default int order()` |
+| `LoomInterceptor` | Per-API request/response processing. `void handle(LoomHttpContext, InterceptorChain)` + `default int order()`. Only runs when referenced in `@LoomApi(interceptors = {...})` |
+| `LoomGlobalInterceptor` | Extends `LoomInterceptor`. Runs on every request automatically — no need to reference in `@LoomApi` |
 | `ServiceAccessor` | Entry point for route-based service invocation. `route(name)` returns `RouteInvoker`                  |
 | `RouteInvoker`    | Fluent interface for invoking a route: `.pathVar()`, `.queryParam()`, `.header()`, `.body()`, `.get()`/`.post()`/etc. |
 | `ServiceResponse<T>` | Response wrapper record carrying `data`, `statusCode`, `headers`, `rawBody`, `contentType` with `isSuccessful()`/`isClientError()`/`isServerError()` helpers |
@@ -596,6 +597,37 @@ public class FetchProductBuilder implements LoomBuilder<ProductInfo> {
 | `isSuccessful()`   | `true` if status is 2xx                                  |
 | `isClientError()`  | `true` if status is 4xx                                  |
 | `isServerError()`  | `true` if status is 5xx                                  |
+
+### Global vs Per-API Interceptors
+
+Interceptors come in two flavours:
+
+- **`LoomGlobalInterceptor`** — runs on every request automatically.
+- **`LoomInterceptor`** — per-API; only runs when listed in `@LoomApi(interceptors = {...})`.
+
+```java
+// Global: runs on every request
+@Component
+public class CorrelationIdInterceptor implements LoomGlobalInterceptor {
+    public void handle(LoomHttpContext ctx, InterceptorChain chain) {
+        ctx.setResponseHeader("X-Correlation-ID", UUID.randomUUID().toString());
+        chain.next(ctx);
+    }
+}
+
+// Per-API: only runs when explicitly referenced
+@Component
+public class ApiKeyInterceptor implements LoomInterceptor {
+    public void handle(LoomHttpContext ctx, InterceptorChain chain) {
+        if (!"valid-key".equals(ctx.getHeader("X-API-Key"))) {
+            ctx.setResponseStatus(403);
+            ctx.setResponseBody(Map.of("error", "Forbidden"));
+            return;
+        }
+        chain.next(ctx);
+    }
+}
+```
 
 ### Reading Headers Set by Interceptor
 

--- a/loom-core/src/main/java/io/loom/core/interceptor/LoomGlobalInterceptor.java
+++ b/loom-core/src/main/java/io/loom/core/interceptor/LoomGlobalInterceptor.java
@@ -1,0 +1,11 @@
+package io.loom.core.interceptor;
+
+/**
+ * Marker sub-interface for interceptors that should run on every request.
+ *
+ * <p>Interceptors implementing {@code LoomGlobalInterceptor} are automatically applied
+ * to all APIs. Interceptors implementing only {@link LoomInterceptor} are per-API and
+ * only execute when explicitly referenced via {@code @LoomApi(interceptors = {...})}.
+ */
+public interface LoomGlobalInterceptor extends LoomInterceptor {
+}

--- a/loom-example/src/main/java/io/loom/example/interceptor/CorrelationIdInterceptor.java
+++ b/loom-example/src/main/java/io/loom/example/interceptor/CorrelationIdInterceptor.java
@@ -1,14 +1,14 @@
 package io.loom.example.interceptor;
 
 import io.loom.core.interceptor.InterceptorChain;
+import io.loom.core.interceptor.LoomGlobalInterceptor;
 import io.loom.core.interceptor.LoomHttpContext;
-import io.loom.core.interceptor.LoomInterceptor;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
 
 @Component
-public class CorrelationIdInterceptor implements LoomInterceptor {
+public class CorrelationIdInterceptor implements LoomGlobalInterceptor {
 
     @Override
     public void handle(LoomHttpContext context, InterceptorChain chain) {

--- a/loom-example/src/main/java/io/loom/example/interceptor/RequestLoggingInterceptor.java
+++ b/loom-example/src/main/java/io/loom/example/interceptor/RequestLoggingInterceptor.java
@@ -1,14 +1,14 @@
 package io.loom.example.interceptor;
 
 import io.loom.core.interceptor.InterceptorChain;
+import io.loom.core.interceptor.LoomGlobalInterceptor;
 import io.loom.core.interceptor.LoomHttpContext;
-import io.loom.core.interceptor.LoomInterceptor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public class RequestLoggingInterceptor implements LoomInterceptor {
+public class RequestLoggingInterceptor implements LoomGlobalInterceptor {
 
     @Override
     public int order() { return 1; }

--- a/loom-spring-boot-starter/src/main/java/io/loom/starter/registry/InterceptorRegistry.java
+++ b/loom-spring-boot-starter/src/main/java/io/loom/starter/registry/InterceptorRegistry.java
@@ -1,5 +1,6 @@
 package io.loom.starter.registry;
 
+import io.loom.core.interceptor.LoomGlobalInterceptor;
 import io.loom.core.interceptor.LoomInterceptor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
@@ -13,6 +14,7 @@ public class InterceptorRegistry {
 
     private final Map<Class<? extends LoomInterceptor>, LoomInterceptor> interceptorsByClass;
     private final List<LoomInterceptor> globalInterceptors;
+    private final Set<Class<?>> globalInterceptorClasses;
     private final ConcurrentHashMap<List<Class<? extends LoomInterceptor>>, List<LoomInterceptor>> cache = new ConcurrentHashMap<>();
 
     public InterceptorRegistry(ApplicationContext applicationContext) {
@@ -23,11 +25,18 @@ public class InterceptorRegistry {
             interceptorsByClass.put(interceptor.getClass(), interceptor);
         }
 
+        // Only LoomGlobalInterceptor implementations are treated as global
         this.globalInterceptors = beans.values().stream()
+                .filter(i -> i instanceof LoomGlobalInterceptor)
                 .sorted(Comparator.comparingInt(LoomInterceptor::order))
                 .collect(Collectors.toList());
 
-        log.info("[Loom] Registered {} interceptors", interceptorsByClass.size());
+        this.globalInterceptorClasses = globalInterceptors.stream()
+                .map(Object::getClass)
+                .collect(Collectors.toSet());
+
+        log.info("[Loom] Registered {} interceptors ({} global)",
+                interceptorsByClass.size(), globalInterceptors.size());
     }
 
     public List<LoomInterceptor> getGlobalInterceptors() {
@@ -62,5 +71,9 @@ public class InterceptorRegistry {
 
         combined.sort(Comparator.comparingInt(LoomInterceptor::order));
         return Collections.unmodifiableList(combined);
+    }
+
+    public boolean isGlobal(LoomInterceptor interceptor) {
+        return globalInterceptorClasses.contains(interceptor.getClass());
     }
 }

--- a/loom-spring-boot-starter/src/test/java/io/loom/starter/registry/InterceptorRegistryTest.java
+++ b/loom-spring-boot-starter/src/test/java/io/loom/starter/registry/InterceptorRegistryTest.java
@@ -1,0 +1,225 @@
+package io.loom.starter.registry;
+
+import io.loom.core.interceptor.InterceptorChain;
+import io.loom.core.interceptor.LoomGlobalInterceptor;
+import io.loom.core.interceptor.LoomHttpContext;
+import io.loom.core.interceptor.LoomInterceptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class InterceptorRegistryTest {
+
+    private ApplicationContext applicationContext;
+
+    // --- Test interceptor stubs ---
+
+    static class GlobalAuth implements LoomGlobalInterceptor {
+        @Override
+        public void handle(LoomHttpContext context, InterceptorChain chain) {
+            chain.next(context);
+        }
+
+        @Override
+        public int order() { return 0; }
+    }
+
+    static class GlobalLogging implements LoomGlobalInterceptor {
+        @Override
+        public void handle(LoomHttpContext context, InterceptorChain chain) {
+            chain.next(context);
+        }
+
+        @Override
+        public int order() { return 1; }
+    }
+
+    static class PerApiRateLimit implements LoomInterceptor {
+        @Override
+        public void handle(LoomHttpContext context, InterceptorChain chain) {
+            chain.next(context);
+        }
+
+        @Override
+        public int order() { return 2; }
+    }
+
+    static class PerApiApiKey implements LoomInterceptor {
+        @Override
+        public void handle(LoomHttpContext context, InterceptorChain chain) {
+            chain.next(context);
+        }
+
+        @Override
+        public int order() { return -1; }
+    }
+
+    @BeforeEach
+    void setUp() {
+        applicationContext = mock(ApplicationContext.class);
+    }
+
+    @Test
+    void onlyGlobalInterceptorsAppearInGlobalList() {
+        when(applicationContext.getBeansOfType(LoomInterceptor.class)).thenReturn(Map.of(
+                "globalAuth", new GlobalAuth(),
+                "globalLogging", new GlobalLogging(),
+                "rateLimit", new PerApiRateLimit()
+        ));
+
+        InterceptorRegistry registry = new InterceptorRegistry(applicationContext);
+
+        List<LoomInterceptor> globals = registry.getGlobalInterceptors();
+        assertThat(globals).hasSize(2);
+        assertThat(globals).allMatch(i -> i instanceof LoomGlobalInterceptor);
+    }
+
+    @Test
+    void globalInterceptorsSortedByOrder() {
+        when(applicationContext.getBeansOfType(LoomInterceptor.class)).thenReturn(Map.of(
+                "globalLogging", new GlobalLogging(),
+                "globalAuth", new GlobalAuth()
+        ));
+
+        InterceptorRegistry registry = new InterceptorRegistry(applicationContext);
+
+        List<LoomInterceptor> globals = registry.getGlobalInterceptors();
+        assertThat(globals).hasSize(2);
+        assertThat(globals.get(0)).isInstanceOf(GlobalAuth.class);
+        assertThat(globals.get(1)).isInstanceOf(GlobalLogging.class);
+    }
+
+    @Test
+    void perApiInterceptorsAvailableViaGetInterceptors() {
+        PerApiRateLimit rateLimit = new PerApiRateLimit();
+        when(applicationContext.getBeansOfType(LoomInterceptor.class)).thenReturn(Map.of(
+                "globalAuth", new GlobalAuth(),
+                "rateLimit", rateLimit
+        ));
+
+        InterceptorRegistry registry = new InterceptorRegistry(applicationContext);
+
+        @SuppressWarnings("unchecked")
+        Class<? extends LoomInterceptor>[] classes = new Class[]{PerApiRateLimit.class};
+        List<LoomInterceptor> interceptors = registry.getInterceptors(classes);
+
+        assertThat(interceptors).hasSize(2);
+        assertThat(interceptors).anyMatch(i -> i instanceof GlobalAuth);
+        assertThat(interceptors).anyMatch(i -> i instanceof PerApiRateLimit);
+    }
+
+    @Test
+    void getInterceptorsWithNullClassesReturnsOnlyGlobals() {
+        when(applicationContext.getBeansOfType(LoomInterceptor.class)).thenReturn(Map.of(
+                "globalAuth", new GlobalAuth(),
+                "rateLimit", new PerApiRateLimit()
+        ));
+
+        InterceptorRegistry registry = new InterceptorRegistry(applicationContext);
+
+        List<LoomInterceptor> interceptors = registry.getInterceptors(null);
+        assertThat(interceptors).hasSize(1);
+        assertThat(interceptors.get(0)).isInstanceOf(GlobalAuth.class);
+    }
+
+    @Test
+    void getInterceptorsWithEmptyClassesReturnsOnlyGlobals() {
+        when(applicationContext.getBeansOfType(LoomInterceptor.class)).thenReturn(Map.of(
+                "globalAuth", new GlobalAuth(),
+                "rateLimit", new PerApiRateLimit()
+        ));
+
+        InterceptorRegistry registry = new InterceptorRegistry(applicationContext);
+
+        @SuppressWarnings("unchecked")
+        Class<? extends LoomInterceptor>[] classes = new Class[0];
+        List<LoomInterceptor> interceptors = registry.getInterceptors(classes);
+        assertThat(interceptors).hasSize(1);
+        assertThat(interceptors.get(0)).isInstanceOf(GlobalAuth.class);
+    }
+
+    @Test
+    void globalAndPerApiDeduplication() {
+        GlobalAuth globalAuth = new GlobalAuth();
+        when(applicationContext.getBeansOfType(LoomInterceptor.class)).thenReturn(Map.of(
+                "globalAuth", globalAuth
+        ));
+
+        InterceptorRegistry registry = new InterceptorRegistry(applicationContext);
+
+        // Request per-API list that includes GlobalAuth — should not duplicate it
+        @SuppressWarnings("unchecked")
+        Class<? extends LoomInterceptor>[] classes = new Class[]{GlobalAuth.class};
+        List<LoomInterceptor> interceptors = registry.getInterceptors(classes);
+
+        assertThat(interceptors).hasSize(1);
+        assertThat(interceptors.get(0)).isSameAs(globalAuth);
+    }
+
+    @Test
+    void combinedListSortedByOrder() {
+        when(applicationContext.getBeansOfType(LoomInterceptor.class)).thenReturn(Map.of(
+                "globalLogging", new GlobalLogging(),
+                "globalAuth", new GlobalAuth(),
+                "apiKey", new PerApiApiKey(),
+                "rateLimit", new PerApiRateLimit()
+        ));
+
+        InterceptorRegistry registry = new InterceptorRegistry(applicationContext);
+
+        @SuppressWarnings("unchecked")
+        Class<? extends LoomInterceptor>[] classes = new Class[]{PerApiApiKey.class, PerApiRateLimit.class};
+        List<LoomInterceptor> interceptors = registry.getInterceptors(classes);
+
+        assertThat(interceptors).hasSize(4);
+        // order: -1 (PerApiApiKey), 0 (GlobalAuth), 1 (GlobalLogging), 2 (PerApiRateLimit)
+        assertThat(interceptors.get(0)).isInstanceOf(PerApiApiKey.class);
+        assertThat(interceptors.get(1)).isInstanceOf(GlobalAuth.class);
+        assertThat(interceptors.get(2)).isInstanceOf(GlobalLogging.class);
+        assertThat(interceptors.get(3)).isInstanceOf(PerApiRateLimit.class);
+    }
+
+    @Test
+    void isGlobalReturnsTrueForGlobalInterceptors() {
+        GlobalAuth globalAuth = new GlobalAuth();
+        PerApiRateLimit rateLimit = new PerApiRateLimit();
+        when(applicationContext.getBeansOfType(LoomInterceptor.class)).thenReturn(Map.of(
+                "globalAuth", globalAuth,
+                "rateLimit", rateLimit
+        ));
+
+        InterceptorRegistry registry = new InterceptorRegistry(applicationContext);
+
+        assertThat(registry.isGlobal(globalAuth)).isTrue();
+        assertThat(registry.isGlobal(rateLimit)).isFalse();
+    }
+
+    @Test
+    void emptyGlobalListWhenNoGlobalInterceptorsExist() {
+        when(applicationContext.getBeansOfType(LoomInterceptor.class)).thenReturn(Map.of(
+                "rateLimit", new PerApiRateLimit(),
+                "apiKey", new PerApiApiKey()
+        ));
+
+        InterceptorRegistry registry = new InterceptorRegistry(applicationContext);
+
+        assertThat(registry.getGlobalInterceptors()).isEmpty();
+    }
+
+    @Test
+    void emptyRegistryWhenNoInterceptorsExist() {
+        when(applicationContext.getBeansOfType(LoomInterceptor.class)).thenReturn(Map.of());
+
+        InterceptorRegistry registry = new InterceptorRegistry(applicationContext);
+
+        assertThat(registry.getGlobalInterceptors()).isEmpty();
+        assertThat(registry.getInterceptors(null)).isEmpty();
+    }
+}

--- a/loom-ui/src/main/java/io/loom/ui/LoomUiController.java
+++ b/loom-ui/src/main/java/io/loom/ui/LoomUiController.java
@@ -95,7 +95,10 @@ public class LoomUiController {
     private List<InterceptorDto> resolveInterceptors(ApiDefinition api) {
         List<LoomInterceptor> interceptors = interceptorRegistry.getInterceptors(api.interceptors());
         return interceptors.stream()
-                .map(i -> new InterceptorDto(i.getClass().getSimpleName(), i.order()))
+                .map(i -> new InterceptorDto(
+                        i.getClass().getSimpleName(),
+                        i.order(),
+                        interceptorRegistry.isGlobal(i)))
                 .toList();
     }
 
@@ -125,6 +128,7 @@ public class LoomUiController {
 
     public record InterceptorDto(
             String name,
-            int order
+            int order,
+            boolean global
     ) {}
 }

--- a/loom-ui/src/main/resources/static/loom/loom.css
+++ b/loom-ui/src/main/resources/static/loom/loom.css
@@ -341,6 +341,22 @@ body {
     opacity: 0.7;
 }
 
+.interceptor-global {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    font-weight: 700;
+    font-family: var(--font-mono);
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: rgba(52,211,153,0.2);
+    color: var(--green);
+    border: 1px solid rgba(52,211,153,0.35);
+    flex-shrink: 0;
+}
+
 /* ── DAG Section Label ────────────────────────────── */
 .dag-section-label {
     padding: 16px 32px 0;

--- a/loom-ui/src/main/resources/static/loom/loom.js
+++ b/loom-ui/src/main/resources/static/loom/loom.js
@@ -79,7 +79,9 @@
             const node = document.createElement('span');
             node.className = 'interceptor-node node-interceptor';
             node.style.animationDelay = `${(i + 1) * 0.08}s`;
-            node.innerHTML = `${formatInterceptorName(interceptor.name)} <span class="interceptor-order">#${interceptor.order}</span>`;
+            const globalBadge = interceptor.global
+                ? '<span class="interceptor-global">G</span>' : '';
+            node.innerHTML = `${formatInterceptorName(interceptor.name)} ${globalBadge}<span class="interceptor-order">#${interceptor.order}</span>`;
             pipeline.appendChild(node);
         });
 


### PR DESCRIPTION
## Summary

- Introduces `LoomGlobalInterceptor` marker sub-interface so only interceptors that explicitly opt in run on every request; plain `LoomInterceptor` implementations are per-API only
- Updates `InterceptorRegistry` to filter globals via `instanceof LoomGlobalInterceptor` at startup (zero per-request overhead)
- Adds `isGlobal()` query method and UI badges distinguishing global vs per-API interceptors in the DAG visualization

## Test plan

- [x] `InterceptorRegistryTest` — 9 tests covering global filtering, ordering, per-API inclusion, deduplication, `isGlobal()`, and edge cases
- [x] `mvn clean install` passes across all modules

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)